### PR TITLE
SHRINKDESC-23 (b)- Implemented with Reader

### DIFF
--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDefTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDefTestCase.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.shrinkwrap.descriptor.impl.spec.servlet.web;
 
-import java.io.ByteArrayOutputStream;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.logging.Logger;
 
 import javax.faces.application.StateManager;
@@ -80,9 +80,9 @@ public class WebAppDefTestCase
 
       log.fine(webApp);
 
-      ByteArrayOutputStream expected = getResourceContents("/test-web.xml");
+      String expected = getResourceContents("/test-web.xml");
 
-      Assert.assertEquals(expected.toString(), webApp);
+      Assert.assertEquals(expected, webApp);
    }
 
    @Test
@@ -93,9 +93,9 @@ public class WebAppDefTestCase
 
       log.fine(webApp);
 
-      ByteArrayOutputStream expected = getResourceContents("/test-filter-web.xml");
+      String expected = getResourceContents("/test-filter-web.xml");
 
-      Assert.assertEquals(expected.toString(), webApp);
+      Assert.assertEquals(expected, webApp);
    }
 
    @Test
@@ -106,9 +106,9 @@ public class WebAppDefTestCase
 
       log.fine(webApp);
 
-      ByteArrayOutputStream expected = getResourceContents("/test-servlet-web.xml");
+      String expected = getResourceContents("/test-servlet-web.xml");
 
-      Assert.assertEquals(expected.toString(), webApp);
+      Assert.assertEquals(expected, webApp);
    }
 
    @Test
@@ -118,9 +118,9 @@ public class WebAppDefTestCase
 
       log.fine(webApp);
 
-      ByteArrayOutputStream expected = getResourceContents("/test-attributes-web.xml");
+      String expected = getResourceContents("/test-attributes-web.xml");
 
-      Assert.assertEquals(expected.toString(), webApp);
+      Assert.assertEquals(expected, webApp);
    }
 
    @Test
@@ -132,33 +132,23 @@ public class WebAppDefTestCase
 
       log.fine(webApp);
 
-      ByteArrayOutputStream expected = getResourceContents("/test-session-config-web.xml");
+      String expected = getResourceContents("/test-session-config-web.xml");
 
-      Assert.assertEquals(expected.toString(), webApp);
+      Assert.assertEquals(expected, webApp);
    }
 
-   private ByteArrayOutputStream getResourceContents(String resource) throws Exception
+   private String getResourceContents(String resource) throws Exception
    {
       assert resource != null && resource.length() > 0 : "Resource must be specified";
-      final InputStream in = getClass().getResourceAsStream(resource);
-      
-      
-      int bufferSize = 1024*8;
-      final ByteArrayOutputStream out = new ByteArrayOutputStream(bufferSize * 2);
-      final byte[] buffer = new byte[bufferSize];
-      int read = 0;
-      try
+      final BufferedReader reader = new BufferedReader(new InputStreamReader(getClass().getResourceAsStream(resource)));
+      final StringBuffer builder = new StringBuffer();
+      String line;
+      while ((line = reader.readLine()) != null)
       {
-         while (((read = in.read(buffer)) != -1))
-         {
-            out.write(buffer, 0, read);
-         }
+         builder.append(line);
+         builder.append("\n");
       }
-      finally
-      {
-         in.close();
-      }
-
-      return out;
+      return builder.toString();
    }
+
 }


### PR DESCRIPTION
Implemented the fix for the failing tests with carriage returns in the expected web-xxx.xml files as a platform independent solution as per ALR's suggestion. 
The resource files are read in line by line using a buffered reader which removes the CRLF issues. 

(I re-forked the source for this issue because I was having some CRLF issues of my own which caused the whole file to be changed as I was working from Windows and I'm still trying to get the hang of Git, so apologies for the secondary fork). 
