### PR TITLE
SHRINKDESC-24 - Problems with the version attribute in the persistence xml output

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/spec/jpa/persistence/PersistenceDescriptor.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/spec/jpa/persistence/PersistenceDescriptor.java
@@ -27,4 +27,5 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 public interface PersistenceDescriptor extends Descriptor
 {
    PersistenceUnitDef persistenceUnit(String name);
+   PersistenceDescriptor version(String version);
 }

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorImpl.java
@@ -70,6 +70,16 @@ public class PersistenceDescriptorImpl extends SchemaDescriptorImplBase<Persiste
 
    /**
     * {@inheritDoc}
+    * @see org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor#version(java.lang.String)
+    */
+   @Override
+   public PersistenceDescriptor version(String version) {
+	  model.setVersion(version);
+	  return this;
+   }
+   
+   /**
+    * {@inheritDoc}
     * @see org.jboss.shrinkwrap.descriptor.spi.SchemaDescriptorProvider#getSchemaModel()
     */
    @Override

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceModel.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceModel.java
@@ -41,6 +41,8 @@ import org.jboss.shrinkwrap.descriptor.spi.SchemaModel;
 @XmlRootElement(name = "persistence")
 public class PersistenceModel implements SchemaModel
 {
+   public static final String DEFAULT_VERSION = "2.0";
+   
    //-------------------------------------------------------------------------------------||
    // Instance Members -------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -50,7 +52,7 @@ public class PersistenceModel implements SchemaModel
 
    @XmlAttribute(required = true)
    @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-   protected String version;
+   protected String version = DEFAULT_VERSION;
 
    //-------------------------------------------------------------------------------------||
    // Constructor ------------------------------------------------------------------------||
@@ -95,14 +97,7 @@ public class PersistenceModel implements SchemaModel
    @Override
    public String getVersion()
    {
-      if (version == null)
-      {
-         return "2.0";
-      }
-      else
-      {
-         return version;
-      }
+      return version;
    }
 
    /**

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorTestCase.java
@@ -41,6 +41,20 @@ public class PersistenceDescriptorTestCase
    private String name2 = PersistenceDescriptorTestCase.class.getSimpleName() + "2";
    
    @Test
+   public void shouldHaveDefaultVersion() throws Exception
+   {
+	   String desc = create().exportAsString();
+	   assertXPath(desc, "/persistence/@version", "2.0");
+   }
+
+   @Test
+   public void shouldBeAbleToSetVersion() throws Exception
+   {
+	   String desc = create().version("1.0").exportAsString();
+	   assertXPath(desc, "/persistence/@version", "1.0");
+   }
+   
+   @Test
    public void shouldBeAbleToAddPersistenceUnit() throws Exception
    {
       String desc = create()


### PR DESCRIPTION
Version isn't appearing which is causing a problem upon deployment. The problem is that the lazy logic is only in the getter while the XML generator is set up to use field access (so the value is null). Plus the version value is not accessible in the descriptor so I've added the access to that.
