### PR TITLE
Shrinkdesc 38 - Descriptor.getDescriptorName

### DIFF
--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/Descriptor.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/Descriptor.java
@@ -27,6 +27,13 @@ import java.io.OutputStream;
 public interface Descriptor
 {
    /**
+    * Get the Descriptor name. The name can be specified by user or predefined.
+    * 
+    * @return the descriptor name
+    */
+   String getDescriptorName();
+   
+   /**
     * Exports the descriptor XML as a {@link String}
     * @return
     * @throws DescriptorExportException

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/DescriptorConstructionInfo.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/DescriptorConstructionInfo.java
@@ -42,6 +42,11 @@ class DescriptorConstructionInfo
     */
    final Class<? extends DescriptorImporter<?>> importerClass;
    
+   /**
+    * The default name of the Descriptor 
+    */
+   final String defaultName;
+   
    //-------------------------------------------------------------------------------------||
    // Constructor ------------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -50,9 +55,10 @@ class DescriptorConstructionInfo
     * Creates a new instance using the specified 
     * @param implClassName
     * @param modelClassName
+    * @param defaultName The default name for this Descriptor
     */
    @SuppressWarnings("unchecked")
-   DescriptorConstructionInfo(final String implClassName, String importerClassName)
+   DescriptorConstructionInfo(final String implClassName, String importerClassName, String defaultName)
    {
       // Get the TCCL
       final ClassLoader tccl = AccessController.doPrivileged(GetTcclAction.INSTANCE);
@@ -85,5 +91,6 @@ class DescriptorConstructionInfo
       }
       
       this.importerClass = importerClass;
+      this.defaultName = defaultName;
    }
 }

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/Descriptors.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/api/Descriptors.java
@@ -33,20 +33,39 @@ public final class Descriptors
    }
 
    /**
-    * Creates a new Descriptor instance
+    * Creates a new Descriptor instance, predefined default descriptor name will be used.
+    * 
     * @param <T>
     * @param type
     * @return
+    * @see #create(Class, String)
     */
    public static <T extends Descriptor> T create(final Class<T> type)
    {
-      return DescriptorInstantiator.createFromUserView(type);
+      return create(type, null);
+   }
+
+   /**
+    * Creates a new named Descriptor instance.
+    * 
+    * @param <T>
+    * @param type
+    * @param descriptorName the descriptor name 
+    * @return
+    */
+   public static <T extends Descriptor> T create(final Class<T> type, String descriptorName)
+   {
+      return DescriptorInstantiator.createFromUserView(type, descriptorName);
    }
 
    public static <T extends Descriptor> DescriptorImporter<T> importAs(final Class<T> type)
    {
-      return DescriptorInstantiator.createImporterFromUserView(type);
+      return importAs(type, null);
+   }
 
+   public static <T extends Descriptor> DescriptorImporter<T> importAs(final Class<T> type, String descriptorName)
+   {
+      return DescriptorInstantiator.createImporterFromUserView(type, descriptorName);
    }
 
    //   public static <T extends Descriptor, X extends Descriptor<T>> X create(Class<X> defType, InputStream xmlStream)

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/DescriptorImplBase.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/DescriptorImplBase.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.shrinkwrap.descriptor.impl.base;
+
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+/**
+ * Base implementation for a Descriptor. 
+ * 
+ * Enforces descriptor name constructor argument contract from extension loading.
+ *
+ * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
+ * @version $Revision: $
+ */
+public abstract class DescriptorImplBase implements Descriptor
+{
+   private final String name;
+
+   /**
+    * Create a named Descriptor. 
+    */
+   public DescriptorImplBase(String name)
+   {
+      this.name = name;
+   }
+   
+   /* (non-Javadoc)
+    * @see org.jboss.shrinkwrap.descriptor.api.Descriptor#getName()
+    */
+   @Override
+   public String getDescriptorName()
+   {
+      return name;
+   }
+}

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/DescriptorImporterBase.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/DescriptorImporterBase.java
@@ -45,7 +45,9 @@ public abstract class DescriptorImporterBase<T extends Descriptor> implements De
     * the model during construction)
     */
    private final Class<T> endUserViewImplType;
-
+   
+   private final String descriptorName; 
+   
    //-------------------------------------------------------------------------------------||
    // Constructor ------------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -56,8 +58,9 @@ public abstract class DescriptorImporterBase<T extends Descriptor> implements De
     * 
     * @param The type of the backing object model for the descriptor
     * @throws IllegalArgumentException If the model type is not specified
+    * @throws IllegalArgumentException If the descriptorName not specified
     */
-   public DescriptorImporterBase(final Class<T> endUserViewImplType)
+   public DescriptorImporterBase(final Class<T> endUserViewImplType, String descriptorName)
          throws IllegalArgumentException
    {
       // Precondition checks
@@ -65,9 +68,15 @@ public abstract class DescriptorImporterBase<T extends Descriptor> implements De
       {
          throw new IllegalArgumentException("End user view impl type must be specified");
       }
+      if (descriptorName == null)
+      {
+         throw new IllegalArgumentException("Descriptor name must be specified");
+      }
+
       // Set
 
       this.endUserViewImplType = endUserViewImplType;
+      this.descriptorName = descriptorName;
    }
 
    @Override
@@ -127,17 +136,17 @@ public abstract class DescriptorImporterBase<T extends Descriptor> implements De
       final Constructor<T> constructor;
       try
       {
-         constructor = endUserViewImplType.getConstructor(Node.class);
+         constructor = endUserViewImplType.getConstructor(String.class, Node.class);
       }
       catch (final NoSuchMethodException e)
       {
          throw new DescriptorImportException("Descriptor impl " + endUserViewImplType.getName()
-               + " does not have a constructor accepting " + Node.class.getName(), e);
+               + " does not have a constructor accepting " + String.class.getName() + " and " + Node.class.getName(), e);
       }
       final T descriptor;
       try
       {
-         descriptor = constructor.newInstance(rootNode);
+         descriptor = constructor.newInstance(descriptorName, rootNode);
       }
       catch (final Exception e)
       {

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/NodeProviderImplBase.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/NodeProviderImplBase.java
@@ -30,9 +30,13 @@ import org.jboss.shrinkwrap.descriptor.spi.NodeProvider;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @version $Revision: $
  */
-public abstract class NodeProviderImplBase implements NodeProvider
+public abstract class NodeProviderImplBase extends DescriptorImplBase implements NodeProvider
 {
-
+   public NodeProviderImplBase(String name)
+   {
+      super(name);
+   }
+   
    /* (non-Javadoc)
     * @see org.jboss.shrinkwrap.descriptor.api.Descriptor#exportAsString()
     */

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/XMLImporter.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/XMLImporter.java
@@ -36,9 +36,9 @@ import org.w3c.dom.NodeList;
  */
 public class XMLImporter<T extends Descriptor> extends DescriptorImporterBase<T>
 {
-   public XMLImporter(final Class<T> endUserViewImplType)
+   public XMLImporter(final Class<T> endUserViewImplType, String descriptorName)
    {
-      super(endUserViewImplType);
+      super(endUserViewImplType, descriptorName);
    }
    
    @Override

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/cdi/beans/BeansDescriptorImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/cdi/beans/BeansDescriptorImpl.java
@@ -46,15 +46,16 @@ public class BeansDescriptorImpl extends NodeProviderImplBase implements BeansDe
    // Constructor ------------------------------------------------------------------------||
    // -------------------------------------------------------------------------------------||
 
-   public BeansDescriptorImpl()
+   public BeansDescriptorImpl(String descriptorName)
    {
-      this(new Node("beans")
+      this(descriptorName, new Node("beans")
                .attribute("xmlns", "http://java.sun.com/xml/ns/javaee")
                .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
    }
 
-   public BeansDescriptorImpl(Node beans)
+   public BeansDescriptorImpl(String descriptorName, Node beans)
    {
+      super(descriptorName);
       this.beans = beans;
    }
 

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/ee/application/ApplicationDescriptorImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/ee/application/ApplicationDescriptorImpl.java
@@ -45,17 +45,18 @@ public class ApplicationDescriptorImpl extends NodeProviderImplBase implements A
    // Constructor ------------------------------------------------------------------------||
    // -------------------------------------------------------------------------------------||
 
-   public ApplicationDescriptorImpl()
+   public ApplicationDescriptorImpl(String descriptorName)
    {
-      this(new Node("application")
+      this(descriptorName, new Node("application")
                .attribute("xmlns", "http://java.sun.com/xml/ns/javaee")
                .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
 
       version("6");
    }
 
-   public ApplicationDescriptorImpl(Node model)
+   public ApplicationDescriptorImpl(String descriptorName, Node model)
    {
+      super(descriptorName);
       this.model = model;
    }
 

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorImpl.java
@@ -45,17 +45,18 @@ public class PersistenceDescriptorImpl extends NodeProviderImplBase
    // Constructor ------------------------------------------------------------------------||
    // -------------------------------------------------------------------------------------||
 
-   public PersistenceDescriptorImpl()
+   public PersistenceDescriptorImpl(String descriptorName)
    {
-      this(new Node("persistence")
+      this(descriptorName, new Node("persistence")
                .attribute("xmlns", "http://java.sun.com/xml/ns/persistence")
                .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance"));
 
       version("2.0");
    }
 
-   public PersistenceDescriptorImpl(final Node model)
+   public PersistenceDescriptorImpl(String descriptorName, final Node model)
    {
+      super(descriptorName);
       this.model = model;
    }
 
@@ -73,6 +74,7 @@ public class PersistenceDescriptorImpl extends NodeProviderImplBase
    {
       // Expression<Node> exp = Expressions.getOrCreate("persistence-unit").attribute("name", name);
       return new PersistenceUnitDefImpl(
+               getDescriptorName(),
                model,
                model.getOrCreate("persistence-unit@name=" + name)).name(name);
    }
@@ -84,7 +86,7 @@ public class PersistenceDescriptorImpl extends NodeProviderImplBase
       List<Node> list = model.get("persistence-unit");
       for (Node node : list)
       {
-         result.add(new PersistenceUnitDefImpl(model, node));
+         result.add(new PersistenceUnitDefImpl(getDescriptorName(), model, node));
       }
       return Collections.unmodifiableList(result);
    }

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceUnitDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceUnitDefImpl.java
@@ -37,9 +37,9 @@ public class PersistenceUnitDefImpl extends PersistenceDescriptorImpl implements
 {
    private final Node persistenceUnit;
 
-   public PersistenceUnitDefImpl(Node persistence, Node persistenceUnit)
+   public PersistenceUnitDefImpl(String descriptorName, Node persistence, Node persistenceUnit)
    {
-      super(persistence);
+      super(descriptorName, persistence);
       this.persistenceUnit = persistenceUnit;
    }
 

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/CookieConfigDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/CookieConfigDefImpl.java
@@ -24,9 +24,9 @@ import org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.CookieConfigDef;
  */
 public class CookieConfigDefImpl extends WebAppDescriptorImpl implements CookieConfigDef
 {
-   public CookieConfigDefImpl(Node webApp)
+   public CookieConfigDefImpl(String descriptorName, Node webApp)
    {
-      super(webApp);
+      super(descriptorName, webApp);
    }
    
    private Node cookieConfig()

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/FilterDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/FilterDefImpl.java
@@ -36,9 +36,9 @@ public class FilterDefImpl extends WebAppDescriptorImpl implements FilterDef
 {
    private final Node filter;
 
-   public FilterDefImpl(final Node webApp, final Node filter)
+   public FilterDefImpl(String descriptorName, final Node webApp, final Node filter)
    {
-      super(webApp);
+      super(descriptorName, webApp);
       this.filter = filter;
    }
 
@@ -84,7 +84,7 @@ public class FilterDefImpl extends WebAppDescriptorImpl implements FilterDef
    @Override
    public FilterDef initParam(String name, Object value)
    {
-      InitParamDefImpl param = new InitParamDefImpl(getRootNode(), filter);
+      InitParamDefImpl param = new InitParamDefImpl(getDescriptorName(), getRootNode(), filter);
       param.initParam(name, value == null ? null : value.toString());
       return this;
    }
@@ -119,7 +119,7 @@ public class FilterDefImpl extends WebAppDescriptorImpl implements FilterDef
    public FilterMappingDef mapping()
    {
       Node mappingNode = getRootNode().create("filter-mapping");
-      FilterMappingDefImpl mapping = new FilterMappingDefImpl(getRootNode(), filter, mappingNode);
+      FilterMappingDefImpl mapping = new FilterMappingDefImpl(getDescriptorName(), getRootNode(), filter, mappingNode);
       mapping.filterName(getName());
       return mapping;
    }

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/FilterMappingDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/FilterMappingDefImpl.java
@@ -34,9 +34,9 @@ public class FilterMappingDefImpl extends FilterDefImpl implements FilterMapping
 {
    private final Node mapping;
 
-   public FilterMappingDefImpl(Node rootNode, Node filter, Node mapping)
+   public FilterMappingDefImpl(String descriptorName, Node rootNode, Node filter, Node mapping)
    {
-      super(rootNode, filter);
+      super(descriptorName, rootNode, filter);
       this.mapping = mapping;
    }
 

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/InitParamDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/InitParamDefImpl.java
@@ -27,9 +27,9 @@ public class InitParamDefImpl extends WebAppDescriptorImpl implements InitParamD
 {
    protected Node child;
    
-   public InitParamDefImpl(Node webApp, Node child)
+   public InitParamDefImpl(String descriptorName, Node webApp, Node child)
    {
-      super(webApp);
+      super(descriptorName, webApp);
       this.child = child;
    }
    

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/SecurityConstraintDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/SecurityConstraintDefImpl.java
@@ -29,9 +29,9 @@ public class SecurityConstraintDefImpl extends WebAppDescriptorImpl implements S
 {
    protected Node securityConstraint;
    
-   public SecurityConstraintDefImpl(Node webApp, Node securityConstraint)
+   public SecurityConstraintDefImpl(String descriptorName, Node webApp, Node securityConstraint)
    {
-      super(webApp);
+      super(descriptorName, webApp);
       this.securityConstraint = securityConstraint;
    }
    
@@ -50,7 +50,7 @@ public class SecurityConstraintDefImpl extends WebAppDescriptorImpl implements S
          resource.create("web-resource-name").text(name);
       }
       
-      return new WebResourceCollectionDefImpl(getRootNode(), securityConstraint, resource);
+      return new WebResourceCollectionDefImpl(getDisplayName(), getRootNode(), securityConstraint, resource);
    }
    
    // TODO maybe remove this

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/ServletDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/ServletDefImpl.java
@@ -40,9 +40,9 @@ public class ServletDefImpl extends WebAppDescriptorImpl implements ServletDef
 {
    private final Node servlet;
 
-   public ServletDefImpl(Node webApp, Node servlet)
+   public ServletDefImpl(String descriptorName, Node webApp, Node servlet)
    {
-      super(webApp);
+      super(descriptorName, webApp);
       this.servlet = servlet;
    }
 
@@ -63,7 +63,7 @@ public class ServletDefImpl extends WebAppDescriptorImpl implements ServletDef
    @Override
    public ServletDef initParam(String name, Object value)
    {
-      InitParamDefImpl param = new InitParamDefImpl(getRootNode(), servlet);
+      InitParamDefImpl param = new InitParamDefImpl(getDescriptorName(), getRootNode(), servlet);
       param.initParam(name, value == null ? null : value.toString());
       return this;
    }
@@ -79,7 +79,7 @@ public class ServletDefImpl extends WebAppDescriptorImpl implements ServletDef
    public ServletMappingDef mapping()
    {
       Node mappingNode = getRootNode().create("servlet-mapping");
-      ServletMappingDef mapping = new ServletMappingDefImpl(getRootNode(), servlet, mappingNode);
+      ServletMappingDef mapping = new ServletMappingDefImpl(getDescriptorName(), getRootNode(), servlet, mappingNode);
       mapping.servletName(getName());
       return mapping;
    }

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/ServletMappingDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/ServletMappingDefImpl.java
@@ -34,9 +34,9 @@ public class ServletMappingDefImpl extends ServletDefImpl implements ServletMapp
 {
    private final Node mapping;
 
-   public ServletMappingDefImpl(Node webApp, Node servletNode, Node mappingNode)
+   public ServletMappingDefImpl(String descriptorName, Node webApp, Node servletNode, Node mappingNode)
    {
-      super(webApp, servletNode);
+      super(descriptorName, webApp, servletNode);
       this.mapping = mappingNode;
    }
 

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDescriptorImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDescriptorImpl.java
@@ -77,9 +77,9 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
    // Constructor ------------------------------------------------------------------------||
    // -------------------------------------------------------------------------------------||
 
-   public WebAppDescriptorImpl()
+   public WebAppDescriptorImpl(String descriptorName)
    {
-      this(new Node("web-app")
+      this(descriptorName, new Node("web-app")
             .attribute("xmlns", "http://java.sun.com/xml/ns/javaee")
             .attribute("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
             .attribute("xsi:schemaLocation",
@@ -87,8 +87,9 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
       version("3.0");
    }
 
-   public WebAppDescriptorImpl(Node model)
+   public WebAppDescriptorImpl(String descriptorName, Node model)
    {
+      super(descriptorName);
       this.model = model;
    }
 
@@ -194,7 +195,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
       final List<FilterDef> filters = new ArrayList<FilterDef>();
       for (final Node filterNode : model.get(NODE_NAME_FILTER))
       {
-         final FilterDef filter = new FilterDefImpl(model, filterNode);
+         final FilterDef filter = new FilterDefImpl(getDescriptorName(), model, filterNode);
          filters.add(filter);
       }
       return filters;
@@ -223,7 +224,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
             }
          }
 
-         final FilterMappingDef filterMapping = new FilterMappingDefImpl(getRootNode(),
+         final FilterMappingDef filterMapping = new FilterMappingDefImpl(getDescriptorName(), getRootNode(),
                   ((FilterDefImpl) filterDef).getNode(), mappingNode);
          mappings.add(filterMapping);
       }
@@ -255,7 +256,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
       filter.create("filter-name").text(name);
       filter.create("filter-class").text(clazz);
 
-      FilterDef f = new FilterDefImpl(model, filter).mapping().urlPatterns(urlPatterns);
+      FilterDef f = new FilterDefImpl(getDescriptorName(), model, filter).mapping().urlPatterns(urlPatterns);
       return f;
    }
 
@@ -283,7 +284,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
       Node servletNode = model.create("servlet");
       servletNode.create("servlet-name").text(name);
       servletNode.create("servlet-class").text(clazz);
-      ServletDef servlet = new ServletDefImpl(model, servletNode);
+      ServletDef servlet = new ServletDefImpl(getDescriptorName(), model, servletNode);
 
       servlet.mapping().urlPatterns(urlPatterns);
       return servlet;
@@ -332,7 +333,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
    @Override
    public CookieConfigDef sessionCookieConfig()
    {
-      return new CookieConfigDefImpl(model);
+      return new CookieConfigDefImpl(getDescriptorName(), model);
    }
 
    @Override
@@ -403,7 +404,7 @@ public class WebAppDescriptorImpl extends NodeProviderImplBase implements WebApp
       {
          security.create("name").text(displayName);
       }
-      return new SecurityConstraintDefImpl(model, security);
+      return new SecurityConstraintDefImpl(getDescriptorName(), model, security);
    }
 
    @Override

--- a/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebResourceCollectionDefImpl.java
+++ b/api/src/main/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebResourceCollectionDefImpl.java
@@ -27,9 +27,9 @@ public class WebResourceCollectionDefImpl extends SecurityConstraintDefImpl impl
 {
    private Node webResourceCollection;
    
-   public WebResourceCollectionDefImpl(Node webApp, Node securityConstraint, Node webResourceCollection)
+   public WebResourceCollectionDefImpl(String descriptorName, Node webApp, Node securityConstraint, Node webResourceCollection)
    {
-      super(webApp, securityConstraint);
+      super(descriptorName, webApp, securityConstraint);
       this.webResourceCollection = webResourceCollection;
    }
    

--- a/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor
+++ b/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor
@@ -1,2 +1,3 @@
 implClass=org.jboss.shrinkwrap.descriptor.impl.spec.cdi.beans.BeansDescriptorImpl
 importerClass=org.jboss.shrinkwrap.descriptor.impl.base.XMLImporter
+defaultName=beans.xml

--- a/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor
+++ b/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor
@@ -1,2 +1,3 @@
 implClass=org.jboss.shrinkwrap.descriptor.impl.spec.ee.application.ApplicationDescriptorImpl
 importerClass=org.jboss.shrinkwrap.descriptor.impl.base.XMLImporter
+defaultName=application.xml

--- a/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor
+++ b/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor
@@ -1,2 +1,3 @@
 implClass=org.jboss.shrinkwrap.descriptor.impl.spec.jpa.persistence.PersistenceDescriptorImpl
 importerClass=org.jboss.shrinkwrap.descriptor.impl.base.XMLImporter
+defaultName=persistence.xml

--- a/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.WebAppDescriptor
+++ b/api/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.WebAppDescriptor
@@ -1,2 +1,3 @@
 implClass=org.jboss.shrinkwrap.descriptor.impl.spec.servlet.web.WebAppDescriptorImpl
 importerClass=org.jboss.shrinkwrap.descriptor.impl.base.XMLImporter
+defaultName=web.xml

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/base/XMLImporterTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/base/XMLImporterTestCase.java
@@ -90,7 +90,7 @@ public class XMLImporterTestCase
    @SuppressWarnings({"unchecked", "rawtypes"})
    private Node load()
    {
-      return new XMLImporter(Object.class)
+      return new XMLImporter(Object.class, "test.xml")
          .importRootNode(new ByteArrayInputStream(SOURCE.getBytes()));
    }
 }

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/cdi/beans/BeansDescriptorTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/cdi/beans/BeansDescriptorTestCase.java
@@ -23,6 +23,8 @@ import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Stereotype;
 import javax.interceptor.Interceptor;
 
+import junit.framework.Assert;
+
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor;
 import org.junit.Test;
@@ -49,6 +51,22 @@ public class BeansDescriptorTestCase
    @Decorator
    private class TestDecorator {}
 
+   //-------------------------------------------------------------------------------------||
+   // Basic API --------------------------------------------------------------------------||
+   //-------------------------------------------------------------------------------------||
+   
+   @Test
+   public void shouldCreateDefaultName() throws Exception
+   {
+      Assert.assertEquals("beans.xml", create().getDescriptorName());
+   }
+   
+   @Test
+   public void shouldBeAbleToSetName() throws Exception
+   {
+      Assert.assertEquals("test.xml", Descriptors.create(BeansDescriptor.class, "test.xml").getDescriptorName());
+   }
+   
    //-------------------------------------------------------------------------------------||
    // Alternative StereoTypes ------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/ee/application/ApplicationDescriptorTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/ee/application/ApplicationDescriptorTestCase.java
@@ -17,7 +17,10 @@
 package org.jboss.shrinkwrap.descriptor.impl.spec.ee.application;
 
 import static org.jboss.shrinkwrap.descriptor.impl.spec.AssertXPath.assertXPath;
+import junit.framework.Assert;
+
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.ee.application.ApplicationDescriptor;
 import org.junit.Test;
 
@@ -32,6 +35,18 @@ public class ApplicationDescriptorTestCase
    private String description = "description";
    private String moduleName = "test.jar";
    private String contextRoot = "/";
+
+   @Test
+   public void shouldCreateDefaultName() throws Exception
+   {
+      Assert.assertEquals("application.xml", create().getDescriptorName());
+   }
+
+   @Test
+   public void shouldBeAbleToSetName() throws Exception
+   {
+      Assert.assertEquals("test.xml", Descriptors.create(ApplicationDescriptor.class, "test.xml").getDescriptorName());
+   }
 
    @Test
    public void shouldBeAbleToAddDescription() throws Exception

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/jpa/persistence/PersistenceDescriptorTestCase.java
@@ -17,8 +17,10 @@
 package org.jboss.shrinkwrap.descriptor.impl.spec.jpa.persistence;
 
 import static org.jboss.shrinkwrap.descriptor.impl.spec.AssertXPath.assertXPath;
+import junit.framework.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.PersistenceUnitDef;
 import org.jboss.shrinkwrap.descriptor.api.spec.jpa.persistence.ProviderType;
@@ -39,7 +41,19 @@ public class PersistenceDescriptorTestCase
 {
    private String name = PersistenceDescriptorTestCase.class.getSimpleName();
    private String name2 = PersistenceDescriptorTestCase.class.getSimpleName() + "2";
-   
+
+   @Test
+   public void shouldCreateDefaultName() throws Exception
+   {
+      Assert.assertEquals("persistence.xml", create().getDescriptorName());
+   }
+
+   @Test
+   public void shouldBeAbleToSetName() throws Exception
+   {
+      Assert.assertEquals("test.xml", Descriptors.create(PersistenceDescriptor.class, "test.xml").getDescriptorName());
+   }
+
    @Test
    public void shouldHaveDefaultVersion() throws Exception
    {

--- a/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDefTestCase.java
+++ b/api/src/test/java/org/jboss/shrinkwrap/descriptor/impl/spec/servlet/web/WebAppDefTestCase.java
@@ -26,6 +26,7 @@ import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.spec.cdi.beans.BeansDescriptor;
 import org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.AuthMethodType;
 import org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.FacesProjectStage;
 import org.jboss.shrinkwrap.descriptor.api.spec.servlet.web.FacesStateSavingMethod;
@@ -44,6 +45,7 @@ public class WebAppDefTestCase
 {
    private final Logger log = Logger.getLogger(WebAppDefTestCase.class.getName());
 
+   
    @Test
    @Ignore
    // broken, import / export order, not 100% match on stored xml.
@@ -93,6 +95,18 @@ public class WebAppDefTestCase
       Assert.assertEquals(expected, webApp);
    }
    
+   @Test
+   public void shouldCreateDefaultName() throws Exception
+   {
+      Assert.assertEquals("web.xml", create().getDescriptorName());
+   }
+
+   @Test
+   public void shouldBeAbleToSetName() throws Exception
+   {
+      Assert.assertEquals("test.xml", Descriptors.create(WebAppDescriptor.class, "test.xml").getDescriptorName());
+   }
+
    /**
     * Ensures that the root element has xsi:schemaLocation w/ correct value
     * SHRINKDESC-36


### PR DESCRIPTION
I've added Descriptor name to the Descriptor interface, but how it is implemented makes me wonder.. 

Each time we go down a level in the Descriptor, e.g web.servlet().name() we create a new instance of the lower levels Desc object for so to pass along the current levels state down:

return new ServletDesc(getDescriptorName() /\* main descriptor name _/, getRootNode() /_ parent node _/, servletNode /_ new current node /*)

(getRootNode we could infer from servletNode.parent in the constructor of the child.)

The impl works as is, but what i'm trying to say is.. it won't scale and seems a bit awkward. We don't have this issue in SW since we only have one level wrapped and always refer to the same Archive in the end. 

Not sure which other Descriptor 'global' metadata like Name we need, but if we get more we should consider wrapping some of these object in some other way..
