### PR TITLE
[SHRINKDESC-110] Support Portlet 2.0

### DIFF
--- a/gen/pom.xml
+++ b/gen/pom.xml
@@ -191,6 +191,20 @@
 									</namespaces>
 								</descriptor>
 
+								<descriptor>
+									<pathToXsd>${basedir}/src/main/resources/xsd/portlet-app_2_0.xsd</pathToXsd>
+									<nameSpace>portlet</nameSpace>
+									<packageApi>org.jboss.shrinkwrap.descriptor.api.portletapp20</packageApi>
+									<packageImpl>org.jboss.shrinkwrap.descriptor.impl.portletapp20</packageImpl>
+									<descriptorName>PortletDescriptor</descriptorName>
+									<elementName>portlet-app</elementName>
+									<elementType>portlet:portlet-appType</elementType>
+									<namespaces>
+										<property><name>xmlns</name><value>http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd</value></property>
+										<property><name>xmlns:xsi</name><value>http://www.w3.org/2001/XMLSchema-instance</value></property>
+										<property><name>xsi:schemaLocation</name><value>http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd</value></property>
+									</namespaces>
+								</descriptor>
 							</descriptors>
 						</configuration>
 						<goals>

--- a/gen/src/main/resources/xsd/portlet-app_2_0.xsd
+++ b/gen/src/main/resources/xsd/portlet-app_2_0.xsd
@@ -1,0 +1,830 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:portlet="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" xml:lang="en">
+	<xsd:annotation>
+		<xsd:documentation>
+		This is the XML Schema for the Portlet 2.0 deployment descriptor.
+		</xsd:documentation>
+	</xsd:annotation>
+	<xsd:annotation>
+		<xsd:documentation>
+		The following conventions apply to all J2EE
+		deployment descriptor elements unless indicated otherwise.
+		- In elements that specify a pathname to a file within the
+		  same JAR file, relative filenames (i.e., those not
+		  starting with "/") are considered relative to the root of
+		  the JAR file's namespace.  Absolute filenames (i.e., those
+		  starting with "/") also specify names in the root of the
+		  JAR file's namespace.  In general, relative names are
+		  preferred.  The exception is .war files where absolute
+		  names are preferred for consistency with the Servlet API.
+		</xsd:documentation>
+	</xsd:annotation>
+	<!-- *********************************************************** -->
+	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<xsd:element name="portlet-app" type="portlet:portlet-appType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The portlet-app element is the root of the deployment descriptor
+			for a portlet application. This element has a required attribute version
+			to specify to which version of the schema the deployment descriptor
+			conforms. In order to be a valid JSR 286 portlet application the version
+			must have the value "2.0".
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:unique name="portlet-name-uniqueness">
+			<xsd:annotation>
+				<xsd:documentation>
+				The portlet element contains the name of a portlet.
+				This name must be unique within the portlet application.
+				 </xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath="portlet:portlet"/>
+			<xsd:field xpath="portlet:portlet-name"/>
+		</xsd:unique>
+		<xsd:unique name="custom-portlet-mode-uniqueness">
+			<xsd:annotation>
+				<xsd:documentation>
+				The custom-portlet-mode element contains the portlet-mode.
+				This portlet mode must be unique within the portlet application.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath="portlet:custom-portlet-mode"/>
+			<xsd:field xpath="portlet:portlet-mode"/>
+		</xsd:unique>
+		<xsd:unique name="custom-window-state-uniqueness">
+			<xsd:annotation>
+				<xsd:documentation>
+				The custom-window-state element contains the window-state.
+				This window state must be unique within the portlet application.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath="portlet:custom-window-state"/>
+			<xsd:field xpath="portlet:window-state"/>
+		</xsd:unique>
+		<xsd:unique name="user-attribute-name-uniqueness">
+			<xsd:annotation>
+				<xsd:documentation>
+				The user-attribute element contains the name the attribute.
+				This name must be unique within the portlet application.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath="portlet:user-attribute"/>
+			<xsd:field xpath="portlet:name"/>
+		</xsd:unique>
+		<xsd:unique name="filter-name-uniqueness">
+			<xsd:annotation>
+				<xsd:documentation>
+				The filter element contains the name of a filter.
+				The name must be unique within the portlet application.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:selector xpath="portlet:filter"/>
+			<xsd:field xpath="portlet:filter-name"/>
+		</xsd:unique>
+	</xsd:element>
+	<xsd:complexType name="portlet-appType">
+		<xsd:sequence>
+			<xsd:element name="portlet" type="portlet:portletType" minOccurs="0" maxOccurs="unbounded">
+				<xsd:unique name="init-param-name-uniqueness">
+					<xsd:annotation>
+						<xsd:documentation>
+						The init-param element contains the name the attribute.
+						This name must be unique within the portlet.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:selector xpath="portlet:init-param"/>
+					<xsd:field xpath="portlet:name"/>
+				</xsd:unique>
+				<xsd:unique name="supports-mime-type-uniqueness">
+					<xsd:annotation>
+						<xsd:documentation>
+						The supports element contains the supported mime-type.
+						This mime type must be unique within the portlet.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:selector xpath="portlet:supports"/>
+					<xsd:field xpath="mime-type"/>
+				</xsd:unique>
+				<xsd:unique name="preference-name-uniqueness">
+					<xsd:annotation>
+						<xsd:documentation>
+						The preference element contains the name the preference.
+						This name must be unique within the portlet.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:selector xpath="portlet:portlet-preferences/portlet:preference"/>
+					<xsd:field xpath="portlet:name"/>
+				</xsd:unique>
+				<xsd:unique name="security-role-ref-name-uniqueness">
+					<xsd:annotation>
+						<xsd:documentation>
+						The security-role-ref element contains the role-name.
+						This role name must be unique within the portlet.
+						</xsd:documentation>
+					</xsd:annotation>
+					<xsd:selector xpath="portlet:security-role-ref"/>
+					<xsd:field xpath="portlet:role-name"/>
+				</xsd:unique>
+			</xsd:element>
+			<xsd:element name="custom-portlet-mode" type="portlet:custom-portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="custom-window-state" type="portlet:custom-window-stateType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="user-attribute" type="portlet:user-attributeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="security-constraint" type="portlet:security-constraintType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
+			<xsd:element name="filter" type="portlet:filterType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="filter-mapping" type="portlet:filter-mappingType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="default-namespace" type="xs:anyURI" minOccurs="0"/>
+			<xsd:element name="event-definition" type="portlet:event-definitionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="public-render-parameter" type="portlet:public-render-parameterType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="listener" type="portlet:listenerType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="version" type="portlet:string" use="required"/>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="cache-scopeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Caching scope, allowed values are "private" indicating that the content should not be shared
+			across users and "public" indicating that the content may be shared across users.
+			The default value if not present is "private".
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="custom-portlet-modeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			A custom portlet mode that one or more portlets in 
+			this portlet application supports.
+			If the portal does not need to provide some management functionality
+			for this portlet mode, the portal-managed element needs to be set
+			to "false", otherwise to "true". Default is "true".
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="portlet-mode" type="portlet:portlet-modeType"/>
+			<xsd:element name="portal-managed" type="portlet:portal-managedType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="custom-window-stateType">
+		<xsd:annotation>
+			<xsd:documentation>
+			A custom window state that one or more portlets in this 
+			portlet application supports.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="window-state" type="portlet:window-stateType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="expiration-cacheType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Expiration-time defines the time in seconds after which the portlet output expires. 
+			-1 indicates that the output never expires.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="xsd:int"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="init-paramType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The init-param element contains a name/value pair as an 
+			initialization param of the portlet
+			Used in:portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="name" type="portlet:nameType"/>
+			<xsd:element name="value" type="portlet:valueType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="keywordsType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Locale specific keywords associated with this portlet.
+			The kewords are separated by commas.
+			Used in: portlet-info
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="mime-typeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			MIME type name, e.g. "text/html".
+			The MIME type may also contain the wildcard
+			character '*', like "text/*" or "*/*".
+			Used in: supports
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="nameType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The name element contains the name of a parameter. 
+			Used in: init-param, ...
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="portletType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The portlet element contains the declarative data of a portlet. 
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="portlet-name" type="portlet:portlet-nameType"/>
+			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="portlet-class" type="portlet:portlet-classType"/>
+			<xsd:element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="expiration-cache" type="portlet:expiration-cacheType" minOccurs="0"/>
+			<xsd:element name="cache-scope" type="portlet:cache-scopeType" minOccurs="0"/>
+			<xsd:element name="supports" type="portlet:supportsType" maxOccurs="unbounded"/>
+			<xsd:element name="supported-locale" type="portlet:supported-localeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
+			<xsd:element name="portlet-info" type="portlet:portlet-infoType" minOccurs="0"/>
+			<xsd:element name="portlet-preferences" type="portlet:portlet-preferencesType" minOccurs="0"/>
+			<xsd:element name="security-role-ref" type="portlet:security-role-refType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="supported-processing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="supported-publishing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="supported-public-render-parameter" type="portlet:string" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:simpleType name="portlet-classType">
+		<xsd:annotation>
+			<xsd:documentation>
+			 The portlet-class element contains the fully
+			 qualified class name of the portlet.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:fully-qualified-classType"/>
+	</xsd:simpleType>
+	<xsd:complexType name="container-runtime-optionType">
+		<xsd:annotation>
+			<xsd:documentation>
+			 The container-runtime-option element contains settings
+			 for the portlet container that the portlet expects to be honored
+			 at runtime. These settings may re-define default portlet container
+			 behavior, like the javax.portlet.escapeXml setting that disables
+			 XML encoding of URLs produced by the portlet tag library as
+			 default.
+			 Names with the javax.portlet prefix are reserved for the Java
+			 Portlet Specification.
+			Used in: portlet-app, portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="name" type="portlet:nameType"/>
+			<xsd:element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="filter-mappingType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Declaration of the filter mappings in this portlet
+			application is done by using filter-mappingType.
+			The container uses the filter-mapping
+			declarations to decide which filters to apply to a request,
+			and in what order. To determine which filters to
+			apply it matches filter-mapping declarations on the
+			portlet-name and the lifecyle phase defined in the
+			filter element. The order in which filters are invoked 
+			is the order in which filter-mapping declarations 
+			that match appear in the list of filter-mapping elements.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="filter-name" type="portlet:filter-nameType"/>
+			<xsd:element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="filterType">
+		<xsd:annotation>
+			<xsd:documentation>
+				The filter element specifies a filter that can transform the 
+				content of portlet requests and portlet responses. 
+				Filters can access the initialization parameters declared in 
+				the deployment descriptor at runtime via the FilterConfig 
+				interface.
+				A filter can be restricted to one or more lifecycle phases
+				of the portlet. Valid entries for lifecycle are:
+				ACTION_PHASE, EVENT_PHASE, RENDER_PHASE,
+				RESOURCE_PHASE
+				Used in: portlet-app
+				</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="filter-name" type="portlet:filter-nameType"/>
+			<xsd:element name="filter-class" type="portlet:fully-qualified-classType"/>
+			<xsd:element name="lifecycle" type="portlet:string" maxOccurs="unbounded"/>
+			<xsd:element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="portlet-collectionType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The portlet-collectionType is used to identify a subset
+			of portlets within a portlet application to which a 
+			security constraint applies.
+			Used in: security-constraint
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="event-definitionType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The event-definitionType is used to declare events the portlet can either
+			receive or emit.
+			The name must be unique and must be the one the 
+			portlet is using in its code for referencing this event.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:choice>
+				<xsd:element name="qname" type="xs:QName"/>
+				<xsd:element name="name" type="xs:NCName"/>
+			</xsd:choice>
+			<xsd:element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="value-type" type="portlet:fully-qualified-classType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="event-definition-referenceType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The event-definition-referenceType is used to reference events 
+			declared with the event-definition element at application level.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:choice>
+			<xsd:element name="qname" type="xs:QName"/>
+			<xsd:element name="name" type="xs:NCName"/>
+		</xsd:choice>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="listenerType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The listenerType is used to declare listeners for this portlet application.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="listener-class" type="portlet:fully-qualified-classType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="portlet-infoType">
+		<xsd:sequence>
+			<xsd:element name="title" type="portlet:titleType" minOccurs="0"/>
+			<xsd:element name="short-title" type="portlet:short-titleType" minOccurs="0"/>
+			<xsd:element name="keywords" type="portlet:keywordsType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:simpleType name="portal-managedType">
+		<xsd:annotation>
+			<xsd:documentation>
+			portal-managed indicates if a custom portlet mode
+			needs to be managed by the portal or not.
+			Per default all custom portlet modes are portal managed.
+			Valid values are: 
+			- true for portal-managed
+			- false for not portal managed
+			Used in: custom-portlet-modes
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:string">
+			<xsd:enumeration value="true"/>
+			<xsd:enumeration value="false"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="portlet-modeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Portlet modes. The specification pre-defines the following values 
+			as valid portlet mode constants: 
+			"edit", "help", "view".
+			Portlet mode names are not case sensitive.
+			Used in: custom-portlet-mode, supports
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="portlet-nameType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The portlet-name element contains the canonical name of the 
+			portlet. Each portlet name is unique within the portlet 
+			application.
+			Used in: portlet, filter-mapping
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="portlet-preferencesType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Portlet persistent preference store.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="preference" type="portlet:preferenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="preferences-validator" type="portlet:preferences-validatorType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="preferenceType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Persistent preference values that may be used for customization 
+			and personalization by the portlet.
+			Used in: portlet-preferences
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="name" type="portlet:nameType"/>
+			<xsd:element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="read-only" type="portlet:read-onlyType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:simpleType name="preferences-validatorType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The class specified under preferences-validator implements
+			the PreferencesValidator interface to validate the 
+			preferences settings.
+			Used in: portlet-preferences
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:fully-qualified-classType"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="read-onlyType">
+		<xsd:annotation>
+			<xsd:documentation>
+			read-only indicates that a setting cannot
+			be changed in any of the standard portlet modes 
+			("view","edit" or "help").
+			Per default all preferences are modifiable.
+			Valid values are: 
+			- true for read-only
+			- false for modifiable
+			Used in: preferences
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:string">
+			<xsd:enumeration value="true"/>
+			<xsd:enumeration value="false"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="resource-bundleType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Name of the resource bundle containing the language specific 
+			portlet informations in different languages (Filename without
+			the language specific part (e.g. _en) and the ending (.properties).
+			Used in: portlet-info
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="role-linkType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The role-link element is a reference to a defined security role. 
+			The role-link element must contain the name of one of the 
+			security roles defined in the security-role elements.
+			Used in: security-role-ref
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="security-constraintType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The security-constraintType is used to associate
+			intended security constraints with one or more portlets.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="portlet-collection" type="portlet:portlet-collectionType"/>
+			<xsd:element name="user-data-constraint" type="portlet:user-data-constraintType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="security-role-refType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The security-role-ref element contains the declaration of a 
+			security role reference in the code of the web application. The 
+			declaration consists of an optional description, the security 
+			role name used in the code, and an optional link to a security 
+			role. If the security role is not specified, the Deployer must 
+			choose an appropriate security role.
+			The value of the role name element must be the String used 
+			as the parameter to the 
+			EJBContext.isCallerInRole(String roleName) method
+			or the HttpServletRequest.isUserInRole(String role) method.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="role-name" type="portlet:role-nameType"/>
+			<xsd:element name="role-link" type="portlet:role-linkType" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="public-render-parameterType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The public-render-parameters defines a render parameter that is allowed to be public
+			and thus be shared with other portlets.
+			The identifier must be used for referencing this public render parameter in the portlet code.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="identifier" type="portlet:string"/>
+			<xsd:choice>
+				<xsd:element name="qname" type="xs:QName"/>
+				<xsd:element name="name" type="xs:NCName"/>
+			</xsd:choice>
+			<xsd:element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="short-titleType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Locale specific short version of the static title.
+			Used in: portlet-info
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="supportsType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Supports indicates the portlet modes a 
+			portlet supports for a specific content type. All portlets must 
+			support the view mode. 
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="mime-type" type="portlet:mime-typeType"/>
+			<xsd:element name="portlet-mode" type="portlet:portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="window-state" type="portlet:window-stateType" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="supported-localeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Indicated the locales the portlet supports.
+			Used in: portlet
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="titleType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Locale specific static title for this portlet.
+			Used in: portlet-info
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="transport-guaranteeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The transport-guaranteeType specifies that 
+			the communication between client and portlet should 
+			be NONE, INTEGRAL, or CONFIDENTIAL. 
+			NONE means that the portlet does not
+			require any transport guarantees. A value of 
+			INTEGRAL means that the portlet requires that the 
+			data sent between the client and portlet be sent in 
+			such a way that it can't be changed in transit. 
+			CONFIDENTIAL means that the portlet requires 
+			that the data be transmitted in a fashion that
+			prevents other entities from observing the contents 
+			of the transmission. 
+			In most cases, the presence of the INTEGRAL or
+			CONFIDENTIAL flag will indicate that the use 
+			of SSL is required.
+ 			Used in: user-data-constraint
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:string">
+			<xsd:enumeration value="NONE"/>
+			<xsd:enumeration value="INTEGRAL"/>
+			<xsd:enumeration value="CONFIDENTIAL"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:complexType name="user-attributeType">
+		<xsd:annotation>
+			<xsd:documentation>
+			User attribute defines a user specific attribute that the
+			portlet application needs. The portlet within this application 
+			can access this attribute via the request parameter USER_INFO
+			map.
+			Used in: portlet-app
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="name" type="portlet:nameType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="user-data-constraintType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The user-data-constraintType is used to indicate how
+			data communicated between the client and portlet should be
+			protected.
+			Used in: security-constraint
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:sequence>
+			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="transport-guarantee" type="portlet:transport-guaranteeType"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="portlet:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="valueType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The value element contains the value of a parameter.
+			Used in: init-param
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="window-stateType">
+		<xsd:annotation>
+			<xsd:documentation>
+			Portlet window state. Window state names are not case sensitive.
+			Used in: custom-window-state
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string"/>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<!--- everything below is copied from j2ee_1_4.xsd -->
+	<xsd:complexType name="descriptionType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The description element is used to provide text describing the 
+			parent element. The description element should include any 
+			information that the portlet application war file producer wants
+			to provide to the consumer of the portlet application war file 
+			(i.e., to the Deployer). Typically, the tools used by the 
+			portlet application war file consumer will display the 
+			description when processing the parent element that contains the 
+			description. It has an optional attribute xml:lang to indicate 
+			which language is used in the description according to 
+			RFC 1766 (http://www.ietf.org/rfc/rfc1766.txt). The default
+			value of this attribute is English(“en”).
+			Used in: init-param, portlet, portlet-app, security-role
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string">
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:complexType name="display-nameType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The display-name type contains a short name that is intended
+			to be displayed by tools. It is used by display-name
+			elements.  The display name need not be unique.
+			Example:
+				...
+  			<xsd:display-name xml:lang="en">Employee Self Service</xsd:display-name>
+
+			It has an optional attribute xml:lang to indicate 
+			which language is used in the description according to 
+			RFC 1766 (http://www.ietf.org/rfc/rfc1766.txt). The default
+			value of this attribute is English(“en”).
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:simpleContent>
+			<xsd:extension base="portlet:string">
+				<xsd:attribute ref="xml:lang"/>
+			</xsd:extension>
+		</xsd:simpleContent>
+	</xsd:complexType>
+	<xsd:simpleType name="fully-qualified-classType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The elements that use this type designate the name of a
+			Java class or interface.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:string"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="role-nameType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The role-nameType designates the name of a security role.
+
+			The name must conform to the lexical rules for an NMTOKEN.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="xsd:NMTOKEN"/>
+	</xsd:simpleType>
+	<xsd:simpleType name="string">
+		<xsd:annotation>
+			<xsd:documentation>
+			This is a special string datatype that is defined by JavaEE 
+			as a base type for defining collapsed strings. When 
+			schemas require trailing/leading space elimination as 
+			well as collapsing the existing whitespace, this base 
+			type may be used.
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="string">
+			<xsd:whiteSpace value="collapse"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	<xsd:simpleType name="filter-nameType">
+		<xsd:annotation>
+			<xsd:documentation>
+			The logical name of the filter is declare
+			by using filter-nameType. This name is used to map the
+			filter.  Each filter name is unique within the portlet
+			application.
+			Used in: filter, filter-mapping
+			</xsd:documentation>
+		</xsd:annotation>
+		<xsd:restriction base="portlet:string"/>
+	</xsd:simpleType>
+</xsd:schema>

--- a/impl-javaee/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.portletapp20.PortletDescriptor
+++ b/impl-javaee/src/main/resources/META-INF/services/org.jboss.shrinkwrap.descriptor.api.portletapp20.PortletDescriptor
@@ -1,0 +1,3 @@
+implClass=org.jboss.shrinkwrap.descriptor.impl.portletapp20.PortletDescriptorImpl
+importerClass=org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeDescriptorImporterImpl
+defaultName=portlet.xml

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portlet20/PortletDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portlet20/PortletDescriptorTestCase.java
@@ -1,0 +1,69 @@
+package org.jboss.shrinkwrap.descriptor.test.portlet20;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.portletapp20.PortletDescriptor;
+import org.jboss.shrinkwrap.descriptor.test.util.XmlAssert;
+import org.junit.Test;
+
+public class PortletDescriptorTestCase
+{
+
+   @Test
+   public void testGeneratedPortletXml() throws Exception
+   {
+      final PortletDescriptor portlet = create()
+            .addDefaultNamespaces()
+            .version("2.0")
+            .createPortlet()
+            	.portletName("HelloPortlet")
+            	.portletClass("javax.portlet.faces.GenericFacesPortlet")
+            	.createInitParam()
+            		.name("javax.portlet.faces.defaultViewId.view")
+            		.value("/view.jsp").up()
+            	.createInitParam()
+            		.name("javax.portlet.faces.defaultViewId.edit")
+            		.value("/edit.jsp").up()
+            	.createInitParam()
+            		.name("javax.portlet.faces.defaultViewId.help")
+            		.value("/help.jsp").up()
+            	.createSupports()
+            		.mimeType("text/html")
+            		.portletMode("view")
+            		.portletMode("edit")
+            		.portletMode("help").up()
+            	.getOrCreatePortletInfo()
+            		.title("Hello Portlet")
+            	.up().up();
+      String portletXmlGenerated = portlet.exportAsString();
+      String portletXmlOriginal = getResourceContents("src/test/resources/test-gen-portlet20.xml");
+      System.out.println(portletXmlGenerated);
+      XmlAssert.assertIdentical(portletXmlOriginal, portletXmlGenerated);   
+   }
+   
+   
+   // -------------------------------------------------------------------------------------||
+   // Internal Helper ---------------------------------------------------------------------||
+   // -------------------------------------------------------------------------------------||
+
+   private String getResourceContents(String resource) throws Exception
+   {
+      assert resource != null && resource.length() > 0 : "Resource must be specified";
+      final BufferedReader reader = new BufferedReader(new FileReader(resource));
+      final StringBuilder builder = new StringBuilder();
+      String line;
+      while ((line = reader.readLine()) != null)
+      {
+         builder.append(line);
+         builder.append("\n");
+      }
+      return builder.toString();
+   }
+
+   private PortletDescriptor create()
+   {
+      return Descriptors.create(PortletDescriptor.class);
+   }
+}

--- a/test/src/test/resources/test-gen-portlet20.xml
+++ b/test/src/test/resources/test-gen-portlet20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<portlet-app xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd"
+             version="2.0"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd
+http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd">
+   <portlet>
+      <portlet-name>HelloPortlet</portlet-name>
+      <portlet-class>javax.portlet.faces.GenericFacesPortlet</portlet-class>
+      <init-param>
+         <name>javax.portlet.faces.defaultViewId.view</name>
+         <value>/view.jsp</value>
+      </init-param>
+
+      <init-param>
+         <name>javax.portlet.faces.defaultViewId.edit</name>
+         <value>/edit.jsp</value>
+      </init-param>
+
+      <init-param>
+         <name>javax.portlet.faces.defaultViewId.help</name>
+         <value>/help.jsp</value>
+      </init-param>
+      <supports>
+         <mime-type>text/html</mime-type>
+         <portlet-mode>view</portlet-mode>
+         <portlet-mode>edit</portlet-mode>
+         <portlet-mode>help</portlet-mode>
+      </supports>
+      <portlet-info>
+         <title>Hello Portlet</title>
+      </portlet-info>
+   </portlet>
+</portlet-app>


### PR DESCRIPTION
This is a first implemetation of portlet descriptor.

This isn't a full javaee spec but it's bassed on javaee 1.4, tell me if I can leave the code in the javaee projects (api and impl).
Moreover, I modified the portlet-app_2_0.xsd to add the xsd: namespace. If you prefer no modification, I can provide a patch for the maven plugin to accept tags without xsd: namespace.

Jeremie.
