### PR TITLE
[SHRINKDESC-111] Support XSD files without xsd namespace

### DIFF
--- a/gen/src/main/resources/xsd/portlet-app_2_0.xsd
+++ b/gen/src/main/resources/xsd/portlet-app_2_0.xsd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:portlet="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" xml:lang="en">
-	<xsd:annotation>
-		<xsd:documentation>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:portlet="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://java.sun.com/xml/ns/portlet/portlet-app_2_0.xsd" elementFormDefault="qualified" attributeFormDefault="unqualified" version="2.0" xml:lang="en">
+	<annotation>
+		<documentation>
 		This is the XML Schema for the Portlet 2.0 deployment descriptor.
-		</xsd:documentation>
-	</xsd:annotation>
-	<xsd:annotation>
-		<xsd:documentation>
+		</documentation>
+	</annotation>
+	<annotation>
+		<documentation>
 		The following conventions apply to all J2EE
 		deployment descriptor elements unless indicated otherwise.
 		- In elements that specify a pathname to a file within the
@@ -17,280 +17,280 @@
 		  JAR file's namespace.  In general, relative names are
 		  preferred.  The exception is .war files where absolute
 		  names are preferred for consistency with the Servlet API.
-		</xsd:documentation>
-	</xsd:annotation>
+		</documentation>
+	</annotation>
 	<!-- *********************************************************** -->
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
-	<xsd:element name="portlet-app" type="portlet:portlet-appType">
-		<xsd:annotation>
-			<xsd:documentation>
+	<import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+	<element name="portlet-app" type="portlet:portlet-appType">
+		<annotation>
+			<documentation>
 			The portlet-app element is the root of the deployment descriptor
 			for a portlet application. This element has a required attribute version
 			to specify to which version of the schema the deployment descriptor
 			conforms. In order to be a valid JSR 286 portlet application the version
 			must have the value "2.0".
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:unique name="portlet-name-uniqueness">
-			<xsd:annotation>
-				<xsd:documentation>
+			</documentation>
+		</annotation>
+		<unique name="portlet-name-uniqueness">
+			<annotation>
+				<documentation>
 				The portlet element contains the name of a portlet.
 				This name must be unique within the portlet application.
-				 </xsd:documentation>
-			</xsd:annotation>
-			<xsd:selector xpath="portlet:portlet"/>
-			<xsd:field xpath="portlet:portlet-name"/>
-		</xsd:unique>
-		<xsd:unique name="custom-portlet-mode-uniqueness">
-			<xsd:annotation>
-				<xsd:documentation>
+				 </documentation>
+			</annotation>
+			<selector xpath="portlet:portlet"/>
+			<field xpath="portlet:portlet-name"/>
+		</unique>
+		<unique name="custom-portlet-mode-uniqueness">
+			<annotation>
+				<documentation>
 				The custom-portlet-mode element contains the portlet-mode.
 				This portlet mode must be unique within the portlet application.
-				</xsd:documentation>
-			</xsd:annotation>
-			<xsd:selector xpath="portlet:custom-portlet-mode"/>
-			<xsd:field xpath="portlet:portlet-mode"/>
-		</xsd:unique>
-		<xsd:unique name="custom-window-state-uniqueness">
-			<xsd:annotation>
-				<xsd:documentation>
+				</documentation>
+			</annotation>
+			<selector xpath="portlet:custom-portlet-mode"/>
+			<field xpath="portlet:portlet-mode"/>
+		</unique>
+		<unique name="custom-window-state-uniqueness">
+			<annotation>
+				<documentation>
 				The custom-window-state element contains the window-state.
 				This window state must be unique within the portlet application.
-				</xsd:documentation>
-			</xsd:annotation>
-			<xsd:selector xpath="portlet:custom-window-state"/>
-			<xsd:field xpath="portlet:window-state"/>
-		</xsd:unique>
-		<xsd:unique name="user-attribute-name-uniqueness">
-			<xsd:annotation>
-				<xsd:documentation>
+				</documentation>
+			</annotation>
+			<selector xpath="portlet:custom-window-state"/>
+			<field xpath="portlet:window-state"/>
+		</unique>
+		<unique name="user-attribute-name-uniqueness">
+			<annotation>
+				<documentation>
 				The user-attribute element contains the name the attribute.
 				This name must be unique within the portlet application.
-				</xsd:documentation>
-			</xsd:annotation>
-			<xsd:selector xpath="portlet:user-attribute"/>
-			<xsd:field xpath="portlet:name"/>
-		</xsd:unique>
-		<xsd:unique name="filter-name-uniqueness">
-			<xsd:annotation>
-				<xsd:documentation>
+				</documentation>
+			</annotation>
+			<selector xpath="portlet:user-attribute"/>
+			<field xpath="portlet:name"/>
+		</unique>
+		<unique name="filter-name-uniqueness">
+			<annotation>
+				<documentation>
 				The filter element contains the name of a filter.
 				The name must be unique within the portlet application.
-				</xsd:documentation>
-			</xsd:annotation>
-			<xsd:selector xpath="portlet:filter"/>
-			<xsd:field xpath="portlet:filter-name"/>
-		</xsd:unique>
-	</xsd:element>
-	<xsd:complexType name="portlet-appType">
-		<xsd:sequence>
-			<xsd:element name="portlet" type="portlet:portletType" minOccurs="0" maxOccurs="unbounded">
-				<xsd:unique name="init-param-name-uniqueness">
-					<xsd:annotation>
-						<xsd:documentation>
+				</documentation>
+			</annotation>
+			<selector xpath="portlet:filter"/>
+			<field xpath="portlet:filter-name"/>
+		</unique>
+	</element>
+	<complexType name="portlet-appType">
+		<sequence>
+			<element name="portlet" type="portlet:portletType" minOccurs="0" maxOccurs="unbounded">
+				<unique name="init-param-name-uniqueness">
+					<annotation>
+						<documentation>
 						The init-param element contains the name the attribute.
 						This name must be unique within the portlet.
-						</xsd:documentation>
-					</xsd:annotation>
-					<xsd:selector xpath="portlet:init-param"/>
-					<xsd:field xpath="portlet:name"/>
-				</xsd:unique>
-				<xsd:unique name="supports-mime-type-uniqueness">
-					<xsd:annotation>
-						<xsd:documentation>
+						</documentation>
+					</annotation>
+					<selector xpath="portlet:init-param"/>
+					<field xpath="portlet:name"/>
+				</unique>
+				<unique name="supports-mime-type-uniqueness">
+					<annotation>
+						<documentation>
 						The supports element contains the supported mime-type.
 						This mime type must be unique within the portlet.
-						</xsd:documentation>
-					</xsd:annotation>
-					<xsd:selector xpath="portlet:supports"/>
-					<xsd:field xpath="mime-type"/>
-				</xsd:unique>
-				<xsd:unique name="preference-name-uniqueness">
-					<xsd:annotation>
-						<xsd:documentation>
+						</documentation>
+					</annotation>
+					<selector xpath="portlet:supports"/>
+					<field xpath="mime-type"/>
+				</unique>
+				<unique name="preference-name-uniqueness">
+					<annotation>
+						<documentation>
 						The preference element contains the name the preference.
 						This name must be unique within the portlet.
-						</xsd:documentation>
-					</xsd:annotation>
-					<xsd:selector xpath="portlet:portlet-preferences/portlet:preference"/>
-					<xsd:field xpath="portlet:name"/>
-				</xsd:unique>
-				<xsd:unique name="security-role-ref-name-uniqueness">
-					<xsd:annotation>
-						<xsd:documentation>
+						</documentation>
+					</annotation>
+					<selector xpath="portlet:portlet-preferences/portlet:preference"/>
+					<field xpath="portlet:name"/>
+				</unique>
+				<unique name="security-role-ref-name-uniqueness">
+					<annotation>
+						<documentation>
 						The security-role-ref element contains the role-name.
 						This role name must be unique within the portlet.
-						</xsd:documentation>
-					</xsd:annotation>
-					<xsd:selector xpath="portlet:security-role-ref"/>
-					<xsd:field xpath="portlet:role-name"/>
-				</xsd:unique>
-			</xsd:element>
-			<xsd:element name="custom-portlet-mode" type="portlet:custom-portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="custom-window-state" type="portlet:custom-window-stateType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="user-attribute" type="portlet:user-attributeType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="security-constraint" type="portlet:security-constraintType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
-			<xsd:element name="filter" type="portlet:filterType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="filter-mapping" type="portlet:filter-mappingType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="default-namespace" type="xs:anyURI" minOccurs="0"/>
-			<xsd:element name="event-definition" type="portlet:event-definitionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="public-render-parameter" type="portlet:public-render-parameterType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="listener" type="portlet:listenerType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-		<xsd:attribute name="version" type="portlet:string" use="required"/>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="cache-scopeType">
-		<xsd:annotation>
-			<xsd:documentation>
+						</documentation>
+					</annotation>
+					<selector xpath="portlet:security-role-ref"/>
+					<field xpath="portlet:role-name"/>
+				</unique>
+			</element>
+			<element name="custom-portlet-mode" type="portlet:custom-portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="custom-window-state" type="portlet:custom-window-stateType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="user-attribute" type="portlet:user-attributeType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="security-constraint" type="portlet:security-constraintType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
+			<element name="filter" type="portlet:filterType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="filter-mapping" type="portlet:filter-mappingType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="default-namespace" type="xs:anyURI" minOccurs="0"/>
+			<element name="event-definition" type="portlet:event-definitionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="public-render-parameter" type="portlet:public-render-parameterType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="listener" type="portlet:listenerType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="version" type="portlet:string" use="required"/>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="cache-scopeType">
+		<annotation>
+			<documentation>
 			Caching scope, allowed values are "private" indicating that the content should not be shared
 			across users and "public" indicating that the content may be shared across users.
 			The default value if not present is "private".
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="custom-portlet-modeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="custom-portlet-modeType">
+		<annotation>
+			<documentation>
 			A custom portlet mode that one or more portlets in 
 			this portlet application supports.
 			If the portal does not need to provide some management functionality
 			for this portlet mode, the portal-managed element needs to be set
 			to "false", otherwise to "true". Default is "true".
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="portlet-mode" type="portlet:portlet-modeType"/>
-			<xsd:element name="portal-managed" type="portlet:portal-managedType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="custom-window-stateType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="portlet-mode" type="portlet:portlet-modeType"/>
+			<element name="portal-managed" type="portlet:portal-managedType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="custom-window-stateType">
+		<annotation>
+			<documentation>
 			A custom window state that one or more portlets in this 
 			portlet application supports.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="window-state" type="portlet:window-stateType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="expiration-cacheType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="window-state" type="portlet:window-stateType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="expiration-cacheType">
+		<annotation>
+			<documentation>
 			Expiration-time defines the time in seconds after which the portlet output expires. 
 			-1 indicates that the output never expires.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="xsd:int"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="init-paramType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="int"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="init-paramType">
+		<annotation>
+			<documentation>
 			The init-param element contains a name/value pair as an 
 			initialization param of the portlet
 			Used in:portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="name" type="portlet:nameType"/>
-			<xsd:element name="value" type="portlet:valueType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="keywordsType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="name" type="portlet:nameType"/>
+			<element name="value" type="portlet:valueType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="keywordsType">
+		<annotation>
+			<documentation>
 			Locale specific keywords associated with this portlet.
 			The kewords are separated by commas.
 			Used in: portlet-info
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="mime-typeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="mime-typeType">
+		<annotation>
+			<documentation>
 			MIME type name, e.g. "text/html".
 			The MIME type may also contain the wildcard
 			character '*', like "text/*" or "*/*".
 			Used in: supports
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="nameType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="nameType">
+		<annotation>
+			<documentation>
 			The name element contains the name of a parameter. 
 			Used in: init-param, ...
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="portletType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="portletType">
+		<annotation>
+			<documentation>
 			The portlet element contains the declarative data of a portlet. 
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="portlet-name" type="portlet:portlet-nameType"/>
-			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="portlet-class" type="portlet:portlet-classType"/>
-			<xsd:element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="expiration-cache" type="portlet:expiration-cacheType" minOccurs="0"/>
-			<xsd:element name="cache-scope" type="portlet:cache-scopeType" minOccurs="0"/>
-			<xsd:element name="supports" type="portlet:supportsType" maxOccurs="unbounded"/>
-			<xsd:element name="supported-locale" type="portlet:supported-localeType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
-			<xsd:element name="portlet-info" type="portlet:portlet-infoType" minOccurs="0"/>
-			<xsd:element name="portlet-preferences" type="portlet:portlet-preferencesType" minOccurs="0"/>
-			<xsd:element name="security-role-ref" type="portlet:security-role-refType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="supported-processing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="supported-publishing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="supported-public-render-parameter" type="portlet:string" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:simpleType name="portlet-classType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="portlet-name" type="portlet:portlet-nameType"/>
+			<element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="portlet-class" type="portlet:portlet-classType"/>
+			<element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="expiration-cache" type="portlet:expiration-cacheType" minOccurs="0"/>
+			<element name="cache-scope" type="portlet:cache-scopeType" minOccurs="0"/>
+			<element name="supports" type="portlet:supportsType" maxOccurs="unbounded"/>
+			<element name="supported-locale" type="portlet:supported-localeType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="resource-bundle" type="portlet:resource-bundleType" minOccurs="0"/>
+			<element name="portlet-info" type="portlet:portlet-infoType" minOccurs="0"/>
+			<element name="portlet-preferences" type="portlet:portlet-preferencesType" minOccurs="0"/>
+			<element name="security-role-ref" type="portlet:security-role-refType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="supported-processing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="supported-publishing-event" type="portlet:event-definition-referenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="supported-public-render-parameter" type="portlet:string" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="container-runtime-option" type="portlet:container-runtime-optionType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<simpleType name="portlet-classType">
+		<annotation>
+			<documentation>
 			 The portlet-class element contains the fully
 			 qualified class name of the portlet.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:fully-qualified-classType"/>
-	</xsd:simpleType>
-	<xsd:complexType name="container-runtime-optionType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:fully-qualified-classType"/>
+	</simpleType>
+	<complexType name="container-runtime-optionType">
+		<annotation>
+			<documentation>
 			 The container-runtime-option element contains settings
 			 for the portlet container that the portlet expects to be honored
 			 at runtime. These settings may re-define default portlet container
@@ -300,16 +300,16 @@
 			 Names with the javax.portlet prefix are reserved for the Java
 			 Portlet Specification.
 			Used in: portlet-app, portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="name" type="portlet:nameType"/>
-			<xsd:element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="filter-mappingType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="name" type="portlet:nameType"/>
+			<element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="filter-mappingType">
+		<annotation>
+			<documentation>
 			Declaration of the filter mappings in this portlet
 			application is done by using filter-mappingType.
 			The container uses the filter-mapping
@@ -321,16 +321,16 @@
 			is the order in which filter-mapping declarations 
 			that match appear in the list of filter-mapping elements.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="filter-name" type="portlet:filter-nameType"/>
-			<xsd:element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="filterType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="filter-name" type="portlet:filter-nameType"/>
+			<element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="filterType">
+		<annotation>
+			<documentation>
 				The filter element specifies a filter that can transform the 
 				content of portlet requests and portlet responses. 
 				Filters can access the initialization parameters declared in 
@@ -341,90 +341,90 @@
 				ACTION_PHASE, EVENT_PHASE, RENDER_PHASE,
 				RESOURCE_PHASE
 				Used in: portlet-app
-				</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="filter-name" type="portlet:filter-nameType"/>
-			<xsd:element name="filter-class" type="portlet:fully-qualified-classType"/>
-			<xsd:element name="lifecycle" type="portlet:string" maxOccurs="unbounded"/>
-			<xsd:element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="portlet-collectionType">
-		<xsd:annotation>
-			<xsd:documentation>
+				</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="filter-name" type="portlet:filter-nameType"/>
+			<element name="filter-class" type="portlet:fully-qualified-classType"/>
+			<element name="lifecycle" type="portlet:string" maxOccurs="unbounded"/>
+			<element name="init-param" type="portlet:init-paramType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="portlet-collectionType">
+		<annotation>
+			<documentation>
 			The portlet-collectionType is used to identify a subset
 			of portlets within a portlet application to which a 
 			security constraint applies.
 			Used in: security-constraint
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
-		</xsd:sequence>
-	</xsd:complexType>
-	<xsd:complexType name="event-definitionType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="portlet-name" type="portlet:portlet-nameType" maxOccurs="unbounded"/>
+		</sequence>
+	</complexType>
+	<complexType name="event-definitionType">
+		<annotation>
+			<documentation>
 			The event-definitionType is used to declare events the portlet can either
 			receive or emit.
 			The name must be unique and must be the one the 
 			portlet is using in its code for referencing this event.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:choice>
-				<xsd:element name="qname" type="xs:QName"/>
-				<xsd:element name="name" type="xs:NCName"/>
-			</xsd:choice>
-			<xsd:element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="value-type" type="portlet:fully-qualified-classType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="event-definition-referenceType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<choice>
+				<element name="qname" type="xs:QName"/>
+				<element name="name" type="xs:NCName"/>
+			</choice>
+			<element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="value-type" type="portlet:fully-qualified-classType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="event-definition-referenceType">
+		<annotation>
+			<documentation>
 			The event-definition-referenceType is used to reference events 
 			declared with the event-definition element at application level.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:choice>
-			<xsd:element name="qname" type="xs:QName"/>
-			<xsd:element name="name" type="xs:NCName"/>
-		</xsd:choice>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="listenerType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<choice>
+			<element name="qname" type="xs:QName"/>
+			<element name="name" type="xs:NCName"/>
+		</choice>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="listenerType">
+		<annotation>
+			<documentation>
 			The listenerType is used to declare listeners for this portlet application.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="listener-class" type="portlet:fully-qualified-classType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="portlet-infoType">
-		<xsd:sequence>
-			<xsd:element name="title" type="portlet:titleType" minOccurs="0"/>
-			<xsd:element name="short-title" type="portlet:short-titleType" minOccurs="0"/>
-			<xsd:element name="keywords" type="portlet:keywordsType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:simpleType name="portal-managedType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="listener-class" type="portlet:fully-qualified-classType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="portlet-infoType">
+		<sequence>
+			<element name="title" type="portlet:titleType" minOccurs="0"/>
+			<element name="short-title" type="portlet:short-titleType" minOccurs="0"/>
+			<element name="keywords" type="portlet:keywordsType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<simpleType name="portal-managedType">
+		<annotation>
+			<documentation>
 			portal-managed indicates if a custom portlet mode
 			needs to be managed by the portal or not.
 			Per default all custom portlet modes are portal managed.
@@ -432,82 +432,82 @@
 			- true for portal-managed
 			- false for not portal managed
 			Used in: custom-portlet-modes
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:string">
-			<xsd:enumeration value="true"/>
-			<xsd:enumeration value="false"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:complexType name="portlet-modeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:string">
+			<enumeration value="true"/>
+			<enumeration value="false"/>
+		</restriction>
+	</simpleType>
+	<complexType name="portlet-modeType">
+		<annotation>
+			<documentation>
 			Portlet modes. The specification pre-defines the following values 
 			as valid portlet mode constants: 
 			"edit", "help", "view".
 			Portlet mode names are not case sensitive.
 			Used in: custom-portlet-mode, supports
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="portlet-nameType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="portlet-nameType">
+		<annotation>
+			<documentation>
 			The portlet-name element contains the canonical name of the 
 			portlet. Each portlet name is unique within the portlet 
 			application.
 			Used in: portlet, filter-mapping
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="portlet-preferencesType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="portlet-preferencesType">
+		<annotation>
+			<documentation>
 			Portlet persistent preference store.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="preference" type="portlet:preferenceType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="preferences-validator" type="portlet:preferences-validatorType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="preferenceType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="preference" type="portlet:preferenceType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="preferences-validator" type="portlet:preferences-validatorType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="preferenceType">
+		<annotation>
+			<documentation>
 			Persistent preference values that may be used for customization 
 			and personalization by the portlet.
 			Used in: portlet-preferences
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="name" type="portlet:nameType"/>
-			<xsd:element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="read-only" type="portlet:read-onlyType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:simpleType name="preferences-validatorType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="name" type="portlet:nameType"/>
+			<element name="value" type="portlet:valueType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="read-only" type="portlet:read-onlyType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<simpleType name="preferences-validatorType">
+		<annotation>
+			<documentation>
 			The class specified under preferences-validator implements
 			the PreferencesValidator interface to validate the 
 			preferences settings.
 			Used in: portlet-preferences
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:fully-qualified-classType"/>
-	</xsd:simpleType>
-	<xsd:simpleType name="read-onlyType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:fully-qualified-classType"/>
+	</simpleType>
+	<simpleType name="read-onlyType">
+		<annotation>
+			<documentation>
 			read-only indicates that a setting cannot
 			be changed in any of the standard portlet modes 
 			("view","edit" or "help").
@@ -516,57 +516,57 @@
 			- true for read-only
 			- false for modifiable
 			Used in: preferences
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:string">
-			<xsd:enumeration value="true"/>
-			<xsd:enumeration value="false"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:complexType name="resource-bundleType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:string">
+			<enumeration value="true"/>
+			<enumeration value="false"/>
+		</restriction>
+	</simpleType>
+	<complexType name="resource-bundleType">
+		<annotation>
+			<documentation>
 			Name of the resource bundle containing the language specific 
 			portlet informations in different languages (Filename without
 			the language specific part (e.g. _en) and the ending (.properties).
 			Used in: portlet-info
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="role-linkType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="role-linkType">
+		<annotation>
+			<documentation>
 			The role-link element is a reference to a defined security role. 
 			The role-link element must contain the name of one of the 
 			security roles defined in the security-role elements.
 			Used in: security-role-ref
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="security-constraintType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="security-constraintType">
+		<annotation>
+			<documentation>
 			The security-constraintType is used to associate
 			intended security constraints with one or more portlets.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="portlet-collection" type="portlet:portlet-collectionType"/>
-			<xsd:element name="user-data-constraint" type="portlet:user-data-constraintType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="security-role-refType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="display-name" type="portlet:display-nameType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="portlet-collection" type="portlet:portlet-collectionType"/>
+			<element name="user-data-constraint" type="portlet:user-data-constraintType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="security-role-refType">
+		<annotation>
+			<documentation>
 			The security-role-ref element contains the declaration of a 
 			security role reference in the code of the web application. The 
 			declaration consists of an optional description, the security 
@@ -578,87 +578,87 @@
 			EJBContext.isCallerInRole(String roleName) method
 			or the HttpServletRequest.isUserInRole(String role) method.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="role-name" type="portlet:role-nameType"/>
-			<xsd:element name="role-link" type="portlet:role-linkType" minOccurs="0"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="public-render-parameterType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="role-name" type="portlet:role-nameType"/>
+			<element name="role-link" type="portlet:role-linkType" minOccurs="0"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="public-render-parameterType">
+		<annotation>
+			<documentation>
 			The public-render-parameters defines a render parameter that is allowed to be public
 			and thus be shared with other portlets.
 			The identifier must be used for referencing this public render parameter in the portlet code.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="identifier" type="portlet:string"/>
-			<xsd:choice>
-				<xsd:element name="qname" type="xs:QName"/>
-				<xsd:element name="name" type="xs:NCName"/>
-			</xsd:choice>
-			<xsd:element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="short-titleType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="identifier" type="portlet:string"/>
+			<choice>
+				<element name="qname" type="xs:QName"/>
+				<element name="name" type="xs:NCName"/>
+			</choice>
+			<element name="alias" type="xs:QName" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="short-titleType">
+		<annotation>
+			<documentation>
 			Locale specific short version of the static title.
 			Used in: portlet-info
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="supportsType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="supportsType">
+		<annotation>
+			<documentation>
 			Supports indicates the portlet modes a 
 			portlet supports for a specific content type. All portlets must 
 			support the view mode. 
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="mime-type" type="portlet:mime-typeType"/>
-			<xsd:element name="portlet-mode" type="portlet:portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="window-state" type="portlet:window-stateType" minOccurs="0" maxOccurs="unbounded"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="supported-localeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="mime-type" type="portlet:mime-typeType"/>
+			<element name="portlet-mode" type="portlet:portlet-modeType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="window-state" type="portlet:window-stateType" minOccurs="0" maxOccurs="unbounded"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="supported-localeType">
+		<annotation>
+			<documentation>
 			Indicated the locales the portlet supports.
 			Used in: portlet
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="titleType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="titleType">
+		<annotation>
+			<documentation>
 			Locale specific static title for this portlet.
 			Used in: portlet-info
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="transport-guaranteeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<simpleType name="transport-guaranteeType">
+		<annotation>
+			<documentation>
 			The transport-guaranteeType specifies that 
 			the communication between client and portlet should 
 			be NONE, INTEGRAL, or CONFIDENTIAL. 
@@ -675,71 +675,71 @@
 			CONFIDENTIAL flag will indicate that the use 
 			of SSL is required.
  			Used in: user-data-constraint
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:string">
-			<xsd:enumeration value="NONE"/>
-			<xsd:enumeration value="INTEGRAL"/>
-			<xsd:enumeration value="CONFIDENTIAL"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:complexType name="user-attributeType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:string">
+			<enumeration value="NONE"/>
+			<enumeration value="INTEGRAL"/>
+			<enumeration value="CONFIDENTIAL"/>
+		</restriction>
+	</simpleType>
+	<complexType name="user-attributeType">
+		<annotation>
+			<documentation>
 			User attribute defines a user specific attribute that the
 			portlet application needs. The portlet within this application 
 			can access this attribute via the request parameter USER_INFO
 			map.
 			Used in: portlet-app
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="name" type="portlet:nameType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="user-data-constraintType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="name" type="portlet:nameType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="user-data-constraintType">
+		<annotation>
+			<documentation>
 			The user-data-constraintType is used to indicate how
 			data communicated between the client and portlet should be
 			protected.
 			Used in: security-constraint
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:sequence>
-			<xsd:element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
-			<xsd:element name="transport-guarantee" type="portlet:transport-guaranteeType"/>
-		</xsd:sequence>
-		<xsd:attribute name="id" type="portlet:string" use="optional"/>
-	</xsd:complexType>
-	<xsd:complexType name="valueType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<sequence>
+			<element name="description" type="portlet:descriptionType" minOccurs="0" maxOccurs="unbounded"/>
+			<element name="transport-guarantee" type="portlet:transport-guaranteeType"/>
+		</sequence>
+		<attribute name="id" type="portlet:string" use="optional"/>
+	</complexType>
+	<complexType name="valueType">
+		<annotation>
+			<documentation>
 			The value element contains the value of a parameter.
 			Used in: init-param
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="window-stateType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
+	<complexType name="window-stateType">
+		<annotation>
+			<documentation>
 			Portlet window state. Window state names are not case sensitive.
 			Used in: custom-window-state
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string"/>
-		</xsd:simpleContent>
-	</xsd:complexType>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string"/>
+		</simpleContent>
+	</complexType>
 	<!--- everything below is copied from j2ee_1_4.xsd -->
-	<xsd:complexType name="descriptionType">
-		<xsd:annotation>
-			<xsd:documentation>
+	<complexType name="descriptionType">
+		<annotation>
+			<documentation>
 			The description element is used to provide text describing the 
 			parent element. The description element should include any 
 			information that the portlet application war file producer wants
@@ -752,79 +752,79 @@
 			RFC 1766 (http://www.ietf.org/rfc/rfc1766.txt). The default
 			value of this attribute is English(“en”).
 			Used in: init-param, portlet, portlet-app, security-role
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string">
-				<xsd:attribute ref="xml:lang"/>
-			</xsd:extension>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:complexType name="display-nameType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string">
+				<attribute ref="xml:lang"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="display-nameType">
+		<annotation>
+			<documentation>
 			The display-name type contains a short name that is intended
 			to be displayed by tools. It is used by display-name
 			elements.  The display name need not be unique.
 			Example:
 				...
-  			<xsd:display-name xml:lang="en">Employee Self Service</xsd:display-name>
+  			<display-name xml:lang="en">Employee Self Service</display-name>
 
 			It has an optional attribute xml:lang to indicate 
 			which language is used in the description according to 
 			RFC 1766 (http://www.ietf.org/rfc/rfc1766.txt). The default
 			value of this attribute is English(“en”).
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:simpleContent>
-			<xsd:extension base="portlet:string">
-				<xsd:attribute ref="xml:lang"/>
-			</xsd:extension>
-		</xsd:simpleContent>
-	</xsd:complexType>
-	<xsd:simpleType name="fully-qualified-classType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<simpleContent>
+			<extension base="portlet:string">
+				<attribute ref="xml:lang"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<simpleType name="fully-qualified-classType">
+		<annotation>
+			<documentation>
 			The elements that use this type designate the name of a
 			Java class or interface.
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:string"/>
-	</xsd:simpleType>
-	<xsd:simpleType name="role-nameType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:string"/>
+	</simpleType>
+	<simpleType name="role-nameType">
+		<annotation>
+			<documentation>
 			The role-nameType designates the name of a security role.
 
 			The name must conform to the lexical rules for an NMTOKEN.
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="xsd:NMTOKEN"/>
-	</xsd:simpleType>
-	<xsd:simpleType name="string">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="NMTOKEN"/>
+	</simpleType>
+	<simpleType name="string">
+		<annotation>
+			<documentation>
 			This is a special string datatype that is defined by JavaEE 
 			as a base type for defining collapsed strings. When 
 			schemas require trailing/leading space elimination as 
 			well as collapsing the existing whitespace, this base 
 			type may be used.
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="string">
-			<xsd:whiteSpace value="collapse"/>
-		</xsd:restriction>
-	</xsd:simpleType>
-	<xsd:simpleType name="filter-nameType">
-		<xsd:annotation>
-			<xsd:documentation>
+			</documentation>
+		</annotation>
+		<restriction base="string">
+			<whiteSpace value="collapse"/>
+		</restriction>
+	</simpleType>
+	<simpleType name="filter-nameType">
+		<annotation>
+			<documentation>
 			The logical name of the filter is declare
 			by using filter-nameType. This name is used to map the
 			filter.  Each filter name is unique within the portlet
 			application.
 			Used in: filter, filter-mapping
-			</xsd:documentation>
-		</xsd:annotation>
-		<xsd:restriction base="portlet:string"/>
-	</xsd:simpleType>
-</xsd:schema>
+			</documentation>
+		</annotation>
+		<restriction base="portlet:string"/>
+	</simpleType>
+</schema>

--- a/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/Metadata.java
+++ b/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/Metadata.java
@@ -20,6 +20,8 @@ package org.jboss.shrinkwrap.descriptor.metadata;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jboss.shrinkwrap.descriptor.metadata.filter.XsdDatatypeEnum;
+
 /**
  * This class serves as a sink for all extracted meta-data information.
  *
@@ -315,6 +317,12 @@ public class Metadata
           * replace the xs namespace with xsd, ddJavaAll xslt likes this more 
           */
          element.setType(element.getType().replace("xs:", "xsd:"));
+         
+         /** 
+          * Set default xsd namespace 
+          */
+         if(!element.getType().contains(":") && XsdDatatypeEnum.integer.isDataType("xsd:"+element.getType()))
+        	 element.setType("xsd:"+element.getType());
          
          /**
           * Check java keywords

--- a/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/filter/XsdElementEnum.java
+++ b/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/filter/XsdElementEnum.java
@@ -76,6 +76,8 @@ public enum XsdElementEnum {
          final String[] items = tagName.split(":", -1);
          if (items.length == 2 && items[1].equals(name()))
             return true;
+         if (items.length == 1 && items[0].equals(name()))
+            return true;
       }
       return false;
    }

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portlet20/PortletDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portlet20/PortletDescriptorTestCase.java
@@ -39,7 +39,6 @@ public class PortletDescriptorTestCase
             	.up().up();
       String portletXmlGenerated = portlet.exportAsString();
       String portletXmlOriginal = getResourceContents("src/test/resources/test-gen-portlet20.xml");
-      System.out.println(portletXmlGenerated);
       XmlAssert.assertIdentical(portletXmlOriginal, portletXmlGenerated);   
    }
    


### PR DESCRIPTION
Like you can see with portlet-app_2_0.xsd file and the associated test, this seems to work.

Regards,
Jeremie.
