### PR TITLE
Rename DescriptorImporter.from(String) to DescriptorImporter.fromString(String) - confusing API

### DIFF
--- a/api-base/src/main/java/org/jboss/shrinkwrap/descriptor/api/DescriptorImporter.java
+++ b/api-base/src/main/java/org/jboss/shrinkwrap/descriptor/api/DescriptorImporter.java
@@ -65,11 +65,23 @@ public interface DescriptorImporter<T extends Descriptor>
    T from(InputStream in, boolean close) throws IllegalArgumentException, DescriptorImportException;
 
    /**
-    * Creates a new {@link Descriptor} from the given input {@link String}
+    * Creates a new {@link Descriptor} from the given input XML data {@link String}
+    * 
+    * @param string the resource data
+    * @return the imported descriptor
+    * @throws IllegalArgumentException If the String was not specified
+    * @throws DescriptorImportException
+    */
+   @Deprecated
+   T from(String string) throws IllegalArgumentException, DescriptorImportException;
+   
+   /**
+    * Creates a new {@link Descriptor} from the given input XML data {@link String}
     * @param string the resource URI
     * @return the imported descriptor
     * @throws IllegalArgumentException If the String was not specified
     * @throws DescriptorImportException
     */
-   T from(String string) throws IllegalArgumentException, DescriptorImportException;
+   T fromString(String string) throws IllegalArgumentException, DescriptorImportException;
+      
 }

--- a/impl-base/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/spec/se/manifest/ManifestDescriptorImporter.java
+++ b/impl-base/src/main/java/org/jboss/shrinkwrap/descriptor/impl/base/spec/se/manifest/ManifestDescriptorImporter.java
@@ -100,13 +100,24 @@ public class ManifestDescriptorImporter implements DescriptorImporter<ManifestDe
          }
       }
    }
+   
+   /*
+    * (non-Javadoc)
+    * @see org.jboss.shrinkwrap.descriptor.api.DescriptorImporter#from(java.lang.String)
+    */
+   @Override
+   @Deprecated
+   public ManifestDescriptor from(String manifest) throws IllegalArgumentException, DescriptorImportException
+   {
+       return fromString(manifest);
+   }
 
    /*
     * (non-Javadoc)
     * @see org.jboss.shrinkwrap.descriptor.api.DescriptorImporter#from(java.lang.String)
     */
    @Override
-   public ManifestDescriptor from(String manifest) throws IllegalArgumentException, DescriptorImportException
+   public ManifestDescriptor fromString(String manifest) throws IllegalArgumentException, DescriptorImportException
    {
       if (manifest == null)
          throw new IllegalArgumentException("Manifest cannot be null");

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/DescriptorImporterBase.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/DescriptorImporterBase.java
@@ -116,7 +116,19 @@ public abstract class DescriptorImporterBase<T extends Descriptor> implements De
     * @see org.jboss.shrinkwrap.descriptor.api.DescriptorImporter#from(java.lang.String)
     */
    @Override
+   @Deprecated
    public T from(final String string) throws IllegalArgumentException, DescriptorImportException
+   {
+       return fromString(string);
+   }
+
+          /**
+    * {@inheritDoc}
+    * @see org.jboss.shrinkwrap.descriptor.api.DescriptorImporter#from(java.lang.String)
+    */
+   @Override
+   @Deprecated
+   public T fromString(final String string) throws IllegalArgumentException, DescriptorImportException
    {
       // Precondition check
       if (string == null)


### PR DESCRIPTION
Prior to this change, it was too easy for the reader to assume that the're importing "from" a file, not
the data in the string. See:

https://issues.jboss.org/browse/SHRINKWRAP-400
