### PR TITLE
Fix deprecations and set fork=false on the maven-compiler-plugin

### DIFF
--- a/impl-base/src/test/java/org/jboss/shrinkwrap/descriptor/api/ManifestDescriptorTestCase.java
+++ b/impl-base/src/test/java/org/jboss/shrinkwrap/descriptor/api/ManifestDescriptorTestCase.java
@@ -16,9 +16,9 @@
  */
 package org.jboss.shrinkwrap.descriptor.api;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestCommonDef.CREATED_BY;
 import static org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestCommonDef.JAVA_BEAN;
 import static org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestCommonDef.MAGIC;

--- a/impl-javaee-prototype/src/test/java/org/jboss/shrinkwrap/descriptor/impl/common/DescriptorNameTestDelegate.java
+++ b/impl-javaee-prototype/src/test/java/org/jboss/shrinkwrap/descriptor/impl/common/DescriptorNameTestDelegate.java
@@ -16,21 +16,21 @@
  */
 package org.jboss.shrinkwrap.descriptor.impl.common;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 
 /**
  * Centralizes name-based assertions for {@link Descriptor} tests
- * 
+ *
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
  */
 public class DescriptorNameTestDelegate {
 
     /**
      * Ensures that a newly-created {@link Descriptor} of the specified type defaults to the specified name
-     * 
+     *
      * @param descriptorType
      * @param expectedDefaultName
      * @throws IllegalArgumentException
@@ -50,7 +50,7 @@ public class DescriptorNameTestDelegate {
 
     /**
      * Ensures that a newly-created {@link Descriptor} of the specified type is assigned the specified name
-     * 
+     *
      * @param descriptorType
      * @param explicitName
      * @throws IllegalArgumentException

--- a/impl-javaee-prototype/src/test/java/org/jboss/shrinkwrap/descriptor/impl/webcommon30/FilterTypeTestCase.java
+++ b/impl-javaee-prototype/src/test/java/org/jboss/shrinkwrap/descriptor/impl/webcommon30/FilterTypeTestCase.java
@@ -18,7 +18,7 @@ package org.jboss.shrinkwrap.descriptor.impl.webcommon30;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 /**
  * Test cases asserting the validity of {@link FilterType} operations
- * 
+ *
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
  */
 public class FilterTypeTestCase {

--- a/metadata-parser-test/src/teststatic/java/org/jboss/shrinkwrap/descriptor/test/ironjacamar/ConnectorDescriptorTestCase.java
+++ b/metadata-parser-test/src/teststatic/java/org/jboss/shrinkwrap/descriptor/test/ironjacamar/ConnectorDescriptorTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.shrinkwrap.descriptor.test.ironjacamar;
 import java.io.BufferedReader;
 import java.io.FileReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.connector10.ConnectorDescriptor;
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 public class ConnectorDescriptorTestCase
 {
-   
+
    //-------------------------------------------------------------------------------------||
    // Basic API --------------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -39,9 +39,9 @@ public class ConnectorDescriptorTestCase
    {
       Assert.assertEquals("test.xml", Descriptors.create(ConnectorDescriptor.class, "test.xml").getDescriptorName());
    }
-   
+
    @Test
-   public void testHornetQExample() throws Exception 
+   public void testHornetQExample() throws Exception
    {
       ConnectorDescriptor jca10Generated = create()
       	.displayName("Sample Adapter")
@@ -70,16 +70,16 @@ public class ConnectorDescriptorTestCase
       			.credentialInterface("javax.resource.security.PasswordCredential").up()
       		.reauthenticationSupport("false")
       	.up();
-      	        
+
        String generatedRaXml = jca10Generated.exportAsString();
        String originalRaXml = this.getResourceContents("src/test/resources/test-orig-connector10.xml");
- 
+
 //       System.out.println(generatedRaXml);
-       
-       XmlAssert.assertIdentical(originalRaXml, generatedRaXml);       
+
+       XmlAssert.assertIdentical(originalRaXml, generatedRaXml);
    }
-   
- 
+
+
    //-------------------------------------------------------------------------------------||
    // Internal Helper --------------------------------------------------------------------||
    //-------------------------------------------------------------------------------------||
@@ -97,10 +97,10 @@ public class ConnectorDescriptorTestCase
       }
       return builder.toString();
    }
-   
+
    private ConnectorDescriptor create()
    {
       return Descriptors.create(ConnectorDescriptor.class);
    }
-   
+
 }

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/DomTestUtil.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/DomTestUtil.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
@@ -58,7 +58,7 @@ public class DomTestUtil {
 
     /**
      * Tests the given xmlFragement against the given MetadataElement.
-     * 
+     *
      * @param element
      *            contains the parsed element information.
      * @param xmlFragment
@@ -90,7 +90,7 @@ public class DomTestUtil {
 
     /**
      * Tests the given xmlFragement against the given MetadataElement.
-     * 
+     *
      * @param element
      *            contains the parsed element information.
      * @param xmlFragment
@@ -117,7 +117,7 @@ public class DomTestUtil {
 
     /**
      * Tests the given xmlFragement against the given MetadataElement.
-     * 
+     *
      * @param group
      *            contains the parsed element information.
      * @param xmlFragment

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/MetadataParserTest.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/MetadataParserTest.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.dom.DomWriter;
 import org.jboss.shrinkwrap.descriptor.test.util.XmlAssert;
@@ -28,10 +28,10 @@ public class MetadataParserTest {
 		catch(IllegalArgumentException ex) {
 			isRuntimeExceptionThrown = true;
 		}
-		
+
 		assertTrue(isRuntimeExceptionThrown);
 	}
-	
+
 	@Test
 	public void testParseWithPathNull() throws Exception {
 		final MetadataParser parser = new MetadataParser();
@@ -42,10 +42,10 @@ public class MetadataParserTest {
 		catch(IllegalArgumentException ex) {
 			isRuntimeExceptionThrown = true;
 		}
-		
+
 		Assert.assertTrue(isRuntimeExceptionThrown);
 	}
-	
+
 	@Test
 	public void testParseWithDescriptorsNull() throws Exception {
 		final MetadataParser parser = new MetadataParser();
@@ -56,30 +56,30 @@ public class MetadataParserTest {
 		catch(IllegalArgumentException ex) {
 			isRuntimeExceptionThrown = true;
 		}
-		
+
 		Assert.assertTrue(isRuntimeExceptionThrown);
 	}
-	
+
 	/**
-	 * Tests parsing and generating of the metada XML file. 
+	 * Tests parsing and generating of the metada XML file.
 	 * The test uses a copy of the beans.xsd as test descriptor (testcases.xsd).
 	 * @throws Exception
 	 */
 	@Test
-    public void testParseAndMetadataGeneration() throws Exception {	
+    public void testParseAndMetadataGeneration() throws Exception {
 		final URL url = this.getClass().getResource("/xsd/testcases.xsd");
-		
+
 		final MetadataParserPath path = new MetadataParserPath();
 		path.setPathToApi(null);
 		path.setPathToImpl(null);
 		path.setPathToTest(null);
 		path.setPathToServices(null);
-	
+
 		final Properties prop = new Properties();
 		prop.setProperty("xmlns", "http://java.sun.com/xml/ns/javaee");
 		prop.setProperty("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
 		prop.setProperty("xsi:schemaLocation", "http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/beans_1_0.xsd");
-		
+
 		final MetadataParserConfiguration conf = new MetadataParserConfiguration();
 		conf.setDescriptorName("BeansDescriptor");
 		conf.setElementName("beans");
@@ -91,42 +91,42 @@ public class MetadataParserTest {
 		conf.setPackageImpl("org.jboss.shrinkwrap.descriptor.impl.beans10");
 		conf.setPathToXsd(url.getFile());
 		conf.setVerbose(false);
-		
+
 		final List<MetadataParserConfiguration> confList = new ArrayList<MetadataParserConfiguration>();
 		confList.add(conf);
-		
+
 //		final MetadataJavaDoc javadoc1 = new MetadataJavaDoc();
 //		javadoc1.setTag("@author");
 //		javadoc1.setValue("&lt;a href=&quot;mailto:ralf.battenfeld@bluewin.ch&quot;&gt;Ralf Battenfeld&lt;/a&gt;");
-//		
+//
 //		final MetadataJavaDoc javadoc2 = new MetadataJavaDoc();
 //		javadoc2.setTag("@author");
 //		javadoc2.setValue("&lt;a href=&quot;mailto:alr@jboss.org&quot;&gt;Andrew Lee Rubinger&lt;/a&gt;");
-//		
+//
 //		final List<Object> javadocList = new ArrayList<Object>();
 //		javadocList.add(javadoc1);
 //		javadocList.add(javadoc2);
-		
+
 		final MetadataParser parser = new MetadataParser();
 		parser.parse(path, confList, null, true);
-		
+
 		final String pathToMetadata = parser.getPathToMetadataFile();
 		Assert.assertNotNull(pathToMetadata);
-		
+
 		final URL urlMetadata = this.getClass().getResource("/xsd/tempMetadata3117577610235292908.xml");
-     
+
 		// replace the individual schema location per installation folder with an generic one
 		final String metadataXmlGenerated = getResourceContents(pathToMetadata)
 			.replaceAll("schema=\"([a-zA-Z0-9/-])*testcases.xsd\"", "schema=\"testcases.xsd\"")
 			.replaceAll("schemaName=\"([a-zA-Z0-9/-])*testcases.xsd\"", "schemaName=\"testcases.xsd\"");
-		
+
 		final String metadataXmlOriginal = getResourceContents(urlMetadata.getFile())
 			.replaceAll("schema=\"([a-zA-Z0-9/-])*testcases.xsd\"", "schema=\"testcases.xsd\"")
-			.replaceAll("schemaName=\"([a-zA-Z0-9/-])*testcases.xsd\"", "schemaName=\"testcases.xsd\"");	
-		
-		XmlAssert.assertIdentical(metadataXmlOriginal, metadataXmlGenerated);     
+			.replaceAll("schemaName=\"([a-zA-Z0-9/-])*testcases.xsd\"", "schemaName=\"testcases.xsd\"");
+
+		XmlAssert.assertIdentical(metadataXmlOriginal, metadataXmlGenerated);
     }
-	
+
 
 	//------------------------------------------------------------------------------------------||
 	//--- Private Methods ----------------------------------------------------------------------||
@@ -144,5 +144,5 @@ public class MetadataParserTest {
 		}
 		return builder.toString();
 	}
-	
+
 }

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/AttributeGroupFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/AttributeGroupFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link AttributeGroupFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class AttributeGroupFilterTestCase {

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ComplexTypeFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ComplexTypeFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -11,30 +11,30 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link ComplexTypeFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class ComplexTypeFilterTestCase {
 
 	@Test
-	public void testComplexTypeFilterStandaloneComplexType() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testComplexTypeFilterStandaloneComplexType() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:complexType name=\"emptyType\"/>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
-		Assert.assertEquals("emptyType", metadata.getDataTypeList().get(0).getName(), "emptyType");	
-		Assert.assertEquals("javaee:emptyType", metadata.getDataTypeList().get(0).getMappedTo(), "javaee:emptyType");		
+
+		Assert.assertEquals("emptyType", metadata.getDataTypeList().get(0).getName(), "emptyType");
+		Assert.assertEquals("javaee:emptyType", metadata.getDataTypeList().get(0).getMappedTo(), "javaee:emptyType");
 	}
-	
+
 	@Test
-	public void testComplexTypeFilterWithMixedContent() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testComplexTypeFilterWithMixedContent() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:complexType name=\"loader-repositoryType\" mixed=\"true\">" +
 		"      <xsd:sequence>" +
 		"          <xsd:element name=\"loader-repository-config\" type=\"jboss:loader-repository-configType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>" +
@@ -43,31 +43,31 @@ public class ComplexTypeFilterTestCase {
 		"      <xsd:attribute name=\"loaderRepositoryClass\" type=\"xsd:string\"/>" +
 		"   </xsd:complexType>\">" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
+
         Assert.assertEquals("loader-repositoryType", metadata.getClassList().get(0).getName(), "loader-repositoryType");
-		
+
 		final List<MetadataElement> e = metadata.getClassList().get(0).getElements();
 		DomTestUtil.assertElement(e.get(0), "<xsd:element name=\"loader-repositoryType\" type=\"text\"/>");
 		DomTestUtil.assertElement(e.get(1), "<xsd:element name=\"loader-repository-config\" type=\"jboss:loader-repository-configType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 		DomTestUtil.assertClassAttribute(e.get(2), "<xsd:attribute name=\"id\" type=\"xsd:ID\"/>");
 		DomTestUtil.assertClassAttribute(e.get(3), "<xsd:attribute name=\"loaderRepositoryClass\" type=\"xsd:string\"/>");
 	}
-	
+
 	@Test
-	public void testComplexTypeFilterWithAbstractContent() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testComplexTypeFilterWithAbstractContent() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:complexType name=\"extensibleType\" abstract=\"true\">" +
 		"      <xsd:attribute name=\"id\" type=\"xsd:ID\"/>" +
 		"   </xsd:complexType>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
+
         Assert.assertEquals("extensibleType", metadata.getClassList().get(0).getName(), "extensibleType");
 	}
-	
+
 }

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ElementFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ElementFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link ElementFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class ElementFilterTestCase {
@@ -19,8 +19,8 @@ public class ElementFilterTestCase {
 	@Test
 	public void testElementsWithComplexTypeAsParent() throws Exception {
 		final boolean isLogging = false;
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:complexType name=\"webType\">" +
 		"       <xsd:sequence>" +
 		"           <xsd:element name=\"web-uri\" type=\"javaee:pathType\"></xsd:element> " +
@@ -43,7 +43,7 @@ public class ElementFilterTestCase {
     public void testElementsWithGroupAsParent() throws Exception {
         final boolean isLogging = false;
         final String xmlFragment =
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 	    "   <xsd:group name=\"jndiEnvironmentRefsGroup\">" +
 	    "      <xsd:sequence>" +
 	    "         <xsd:element name=\"env-entry\" type=\"javaee:env-entryType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> " +
@@ -61,30 +61,30 @@ public class ElementFilterTestCase {
 		"      </xsd:sequence>" +
 		"   </xsd:group>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-		
-		Assert.assertEquals("jndiEnvironmentRefsGroup", metadata.getGroupList().get(0).getName(), "jndiEnvironmentRefsGroup");		
-		
+
+		Assert.assertEquals("jndiEnvironmentRefsGroup", metadata.getGroupList().get(0).getName(), "jndiEnvironmentRefsGroup");
+
 		final List<MetadataElement> e = metadata.getGroupList().get(0).getElements();
-		DomTestUtil.assertElement(e.get(0), "<xsd:element name=\"env-entry\" type=\"javaee:env-entryType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");		
-		DomTestUtil.assertElement(e.get(1), "<xsd:element name=\"ejb-ref\" type=\"javaee:ejb-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");		
-		DomTestUtil.assertElement(e.get(2), "<xsd:element name=\"ejb-local-ref\" type=\"javaee:ejb-local-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");		
+		DomTestUtil.assertElement(e.get(0), "<xsd:element name=\"env-entry\" type=\"javaee:env-entryType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");
+		DomTestUtil.assertElement(e.get(1), "<xsd:element name=\"ejb-ref\" type=\"javaee:ejb-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");
+		DomTestUtil.assertElement(e.get(2), "<xsd:element name=\"ejb-local-ref\" type=\"javaee:ejb-local-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 		DomTestUtil.assertElement(e.get(3), "<xsd:element name=\"resource-ref\" type=\"javaee:resource-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
-		DomTestUtil.assertElement(e.get(4), "<xsd:element name=\"resource-env-ref\" type=\"javaee:resource-env-refType\" minOccurs=\"0\"  maxOccurs=\"unbounded\"/>");		
-		DomTestUtil.assertElement(e.get(5), "<xsd:element name=\"message-destination-ref\" type=\"javaee:message-destination-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");		
+		DomTestUtil.assertElement(e.get(4), "<xsd:element name=\"resource-env-ref\" type=\"javaee:resource-env-refType\" minOccurs=\"0\"  maxOccurs=\"unbounded\"/>");
+		DomTestUtil.assertElement(e.get(5), "<xsd:element name=\"message-destination-ref\" type=\"javaee:message-destination-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");
 		DomTestUtil.assertElement(e.get(6), "<xsd:element name=\"persistence-context-ref\" type=\"javaee:persistence-context-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 		DomTestUtil.assertElement(e.get(7), "<xsd:element name=\"persistence-unit-ref\" type=\"javaee:persistence-unit-refType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 		DomTestUtil.assertElement(e.get(8), "<xsd:element name=\"post-construct\" type=\"javaee:lifecycle-callbackType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> ");
 		DomTestUtil.assertElement(e.get(9), "<xsd:element name=\"pre-destroy\" type=\"javaee:lifecycle-callbackType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 		DomTestUtil.assertElement(e.get(10), "<xsd:element name=\"data-source\" type=\"javaee:data-sourceType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>");
 	}
-	
+
 	@Test
 	public void testElementsWithReferencedElements() throws Exception {
 		final boolean isLogging = true;
-		final String xmlFragment = 
-		"<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" + 
+		final String xmlFragment =
+		"<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" +
 	    "   <xs:element name=\"beans\">" +
 	    "      <xs:complexType>" +
 	    "         <xs:choice minOccurs=\"0\" maxOccurs=\"unbounded\">" +
@@ -118,7 +118,7 @@ public class ElementFilterTestCase {
 	    "         </xs:choice>" +
 	    "      </xs:complexType>" +
 	    "   </xs:element>" +
-	    
+
 	    "   <xs:element name=\"scan\">" +
 	    "     <xs:complexType>" +
 	    "       <xs:sequence maxOccurs=\"unbounded\" minOccurs=\"0\">" +
@@ -137,29 +137,29 @@ public class ElementFilterTestCase {
 	    "       </xs:sequence>" +
 	    "     </xs:complexType>" +
 	    "   </xs:element>" +
-	    "</xs:schema>";		
-		
+	    "</xs:schema>";
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-		
+
 		Assert.assertEquals("beans",        metadata.getClassList().get(0).getName(), "beans");
 		Assert.assertEquals("interceptors", metadata.getClassList().get(1).getName(), "interceptors");
 		Assert.assertEquals("decorators",   metadata.getClassList().get(2).getName(), "decorators");
 		Assert.assertEquals("alternatives", metadata.getClassList().get(3).getName(), "alternatives");
 		Assert.assertEquals("scan",         metadata.getClassList().get(4).getName(), "scan");
-		
-		final List<MetadataElement> e = metadata.getClassList().get(0).getElements();		
+
+		final List<MetadataElement> e = metadata.getClassList().get(0).getElements();
 		DomTestUtil.assertElement(e.get(0), "<xs:element ref=\"javaee:interceptors\" />");
 		DomTestUtil.assertElement(e.get(1), "<xs:element ref=\"javaee:decorators\" />");
 		DomTestUtil.assertElement(e.get(2), "<xs:element ref=\"javaee:alternatives\" />");
 		DomTestUtil.assertElement(e.get(3), "<xs:element ref=\"javaee:scan\" />");
-		
-		final List<MetadataElement> e1 = metadata.getClassList().get(1).getElements();		
+
+		final List<MetadataElement> e1 = metadata.getClassList().get(1).getElements();
 		DomTestUtil.assertElement(e1.get(0), "<xs:element name=\"class\" type=\"xs:string\">");
-		
-		final List<MetadataElement> e2 = metadata.getClassList().get(2).getElements();		
+
+		final List<MetadataElement> e2 = metadata.getClassList().get(2).getElements();
 		DomTestUtil.assertElement(e2.get(0), "<xs:element name=\"class\" type=\"xs:string\"></xs:element>");
-		
-		final List<MetadataElement> e3 = metadata.getClassList().get(3).getElements();		
+
+		final List<MetadataElement> e3 = metadata.getClassList().get(3).getElements();
 		DomTestUtil.assertElement(e3.get(0), "<xs:element name=\"class\" type=\"xs:string\"></xs:element>");
 		DomTestUtil.assertElement(e3.get(1), "<xs:element name=\"stereotype\" type=\"xs:string\"></xs:element>");
 	}

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/EnumFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/EnumFilterTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -8,16 +8,16 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link EnumFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class EnumFilterTestCase {
 
 	@Test
-	public void testEnumFilterWithComplexTypeAsParent() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testEnumFilterWithComplexTypeAsParent() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:complexType name=\"ejb-ref-typeType\">" +
 		"      <xsd:simpleContent>" +
 		"          <xsd:restriction base=\"javaee:string\">" +
@@ -27,19 +27,19 @@ public class EnumFilterTestCase {
 		"      </xsd:simpleContent>" +
 		"   </xsd:complexType>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
-		Assert.assertEquals("ejb-ref-typeType", metadata.getEnumList().get(0).getName(), "ejb-ref-typeType");	
+
+		Assert.assertEquals("ejb-ref-typeType", metadata.getEnumList().get(0).getName(), "ejb-ref-typeType");
 		Assert.assertEquals("Entity", metadata.getEnumList().get(0).getValueList().get(0), "Entity");
 		Assert.assertEquals("Session", metadata.getEnumList().get(0).getValueList().get(1), "Session");
 	}
-	
+
 	@Test
-	public void testEnumFilterWithSimpleTypeAsParent() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testEnumFilterWithSimpleTypeAsParent() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:simpleType name=\"isolation-levelType\">" +
 		"      <xsd:restriction base=\"xsd:string\">" +
 		"         <xsd:enumeration value=\"TRANSACTION_READ_UNCOMMITTED\"/>" +
@@ -49,10 +49,10 @@ public class EnumFilterTestCase {
 		"      </xsd:restriction>" +
 		"   </xsd:simpleType>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
-		Assert.assertEquals("isolation-levelType", metadata.getEnumList().get(0).getName(), "isolation-levelType");	
+
+		Assert.assertEquals("isolation-levelType", metadata.getEnumList().get(0).getName(), "isolation-levelType");
 		Assert.assertEquals("TRANSACTION_READ_UNCOMMITTED", metadata.getEnumList().get(0).getValueList().get(0), "TRANSACTION_READ_UNCOMMITTED");
 		Assert.assertEquals("TRANSACTION_READ_COMMITTED", metadata.getEnumList().get(0).getValueList().get(1), "TRANSACTION_READ_COMMITTED");
 		Assert.assertEquals("TRANSACTION_REPEATABLE_READ", metadata.getEnumList().get(0).getValueList().get(2), "TRANSACTION_REPEATABLE_READ");

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ExtensionFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ExtensionFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -20,7 +20,7 @@ public class ExtensionFilterTestCase {
     public void testExtensionWithComplexTypeAsExtension() throws Exception {
         final boolean isLogging = false;
         final String xmlFragment =
-        "<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" + 
+        "<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" +
         "   <xs:complexType name=\"poolType\">" +
         "      <xs:sequence>" +
         "         <xs:element name=\"min-pool-size\" type=\"xs:nonNegativeInteger\" minOccurs=\"0\"></xs:element>" +
@@ -29,7 +29,7 @@ public class ExtensionFilterTestCase {
         "         <xs:element name=\"use-strict-min\" type=\"xs:boolean\" minOccurs=\"0\" maxOccurs=\"1\"> </xs:element>" +
         "         <xs:element name=\"flush-strategy\" type=\"xs:token\" minOccurs=\"0\" maxOccurs=\"1\"></xs:element>" +
         "      </xs:sequence>" +
-        "   </xs:complexType>" +         
+        "   </xs:complexType>" +
         "   <xs:complexType name=\"xa-poolType\">" +
         "      <xs:complexContent>" +
         "         <xs:extension base=\"poolType\">" +

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/GroupFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/GroupFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link GroupFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class GroupFilterTestCase {
@@ -20,7 +20,7 @@ public class GroupFilterTestCase {
     public void testGroupWithGroupAsParent() throws Exception {
         final boolean isLogging = false;
         final String xmlFragment =
-        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
         "   <xsd:group name=\"jndiEnvironmentRefsGroup\">" +
         "      <xsd:sequence>" +
         "         <xsd:element name=\"env-entry\" type=\"javaee:env-entryType\" minOccurs=\"0\" maxOccurs=\"unbounded\"/> " +

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ListFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/ListFilterTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -8,26 +8,26 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link ListFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class ListFilterTestCase {
 
 	@Test
-	public void testListFilterWithSimpleTypeAsParent() throws Exception {		
-		final boolean isLogging = false;		
-		final String xmlFragment = 
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+	public void testListFilterWithSimpleTypeAsParent() throws Exception {
+		final boolean isLogging = false;
+		final String xmlFragment =
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:simpleType name=\"protocol-bindingListType\">" +
 		"      <xsd:list itemType=\"javaee:protocol-bindingType\"/>" +
 		"   </xsd:simpleType>" +
 		"</xsd:schema>";
-		
+
 		final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-				
-		Assert.assertEquals("protocol-bindingListType", metadata.getDataTypeList().get(0).getName(), "protocol-bindingListType");	
-		Assert.assertEquals("protocol-bindingListType", metadata.getDataTypeList().get(0).getMappedTo(), "xsd:string");			
+
+		Assert.assertEquals("protocol-bindingListType", metadata.getDataTypeList().get(0).getName(), "protocol-bindingListType");
+		Assert.assertEquals("protocol-bindingListType", metadata.getDataTypeList().get(0).getMappedTo(), "xsd:string");
 	}
-	
-	
+
+
 }

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/RestrictionFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/RestrictionFilterTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link RestrictionFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class RestrictionFilterTestCase {
@@ -17,7 +17,7 @@ public class RestrictionFilterTestCase {
     public void testRestrictionBaseFilterWithSimpleTypeAsParent() throws Exception {
         final boolean isLogging = false;
         final String xmlFragment =
-        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
         "   <xsd:simpleType name=\"dewey-versionType\">" +
         "       <xsd:restriction base=\"xsd:token\">" +
         "           <xsd:pattern value=\"\\.?[0-9]+(\\.[0-9]+)*\"/>" +
@@ -32,10 +32,10 @@ public class RestrictionFilterTestCase {
     }
 
     @Test
-    public void testRestrictionBaseFilterWithComplexTypeAsParent() throws Exception {        
-        final boolean isLogging = false;        
-        final String xmlFragment = 
-        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+    public void testRestrictionBaseFilterWithComplexTypeAsParent() throws Exception {
+        final boolean isLogging = false;
+        final String xmlFragment =
+        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
         "   <xsd:complexType name=\"ejb-linkType\">" +
         "      <xsd:simpleContent>" +
         "          <xsd:restriction base=\"javaee:string\"/>" +
@@ -50,35 +50,35 @@ public class RestrictionFilterTestCase {
     }
 
     @Test
-    public void testRestrictionBaseFilterWithComplexTypeAsParentUnbound() throws Exception {        
-        final boolean isLogging = true;        
-        final String xmlFragment = 
-        "<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" + 
+    public void testRestrictionBaseFilterWithComplexTypeAsParentUnbound() throws Exception {
+        final boolean isLogging = true;
+        final String xmlFragment =
+        "<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" +
         "<xs:complexType name=\"executable-validationType\">" +
         "  <xs:sequence>" +
         "    <xs:element type=\"config:default-validated-executable-typesType\" name=\"default-validated-executable-types\" minOccurs=\"0\"/>" +
         "  </xs:sequence>" +
         "  <xs:attribute name=\"enabled\" use=\"optional\" type=\"xs:boolean\" default=\"true\"/>" +
         "</xs:complexType>" +
-        "<xs:complexType name=\"default-validated-executable-typesType\">" + 
-        "  <xs:sequence>" + 
-        "    <xs:element name=\"executable-type\" maxOccurs=\"unbounded\" minOccurs=\"1\">" + 
-        "      <xs:simpleType>" + 
-        "        <xs:restriction base=\"xs:string\">" + 
-        "            <xs:enumeration value=\"NONE\"/>" + 
-        "            <xs:enumeration value=\"CONSTRUCTORS\"/>" + 
-        "            <xs:enumeration value=\"NON_GETTER_METHODS\"/>" + 
-        "            <xs:enumeration value=\"GETTER_METHODS\"/>" + 
-        "            <xs:enumeration value=\"ALL\"/>" + 
-        "        </xs:restriction>" + 
-        "      </xs:simpleType>" + 
-        "    </xs:element>" + 
-        "  </xs:sequence>" + 
+        "<xs:complexType name=\"default-validated-executable-typesType\">" +
+        "  <xs:sequence>" +
+        "    <xs:element name=\"executable-type\" maxOccurs=\"unbounded\" minOccurs=\"1\">" +
+        "      <xs:simpleType>" +
+        "        <xs:restriction base=\"xs:string\">" +
+        "            <xs:enumeration value=\"NONE\"/>" +
+        "            <xs:enumeration value=\"CONSTRUCTORS\"/>" +
+        "            <xs:enumeration value=\"NON_GETTER_METHODS\"/>" +
+        "            <xs:enumeration value=\"GETTER_METHODS\"/>" +
+        "            <xs:enumeration value=\"ALL\"/>" +
+        "        </xs:restriction>" +
+        "      </xs:simpleType>" +
+        "    </xs:element>" +
+        "  </xs:sequence>" +
         "</xs:complexType>" +
         "</xs:schema>";
 
 	    final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
-	
+
 	    Assert.assertEquals("executable-validationType", metadata.getClassList().get(0).getName(), "executable-validationType");
 	    Assert.assertEquals("default-validated-executable-typesType", metadata.getClassList().get(1).getName(), "default-validated-executable-typesType");
     }

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/SimpleContentFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/SimpleContentFilterTestCase.java
@@ -2,7 +2,7 @@ package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link UnionFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class SimpleContentFilterTestCase {
@@ -25,13 +25,13 @@ public class SimpleContentFilterTestCase {
         final boolean isLogging = false;
         final String xmlFragment =
         "<xs:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" >" +
-        "   <xs:complexType name=\"propertyType\">" +        
+        "   <xs:complexType name=\"propertyType\">" +
         "         <xs:simpleContent>" +
         "            <xs:extension base=\"xs:string\">" +
         "               <xs:attribute name=\"name\" use=\"required\" type=\"xs:string\" />" +
         "            </xs:extension>" +
         "         </xs:simpleContent>" +
-        "   </xs:complexType>" +       
+        "   </xs:complexType>" +
         "</xs:schema>";
 
         final Metadata metadata = DomTestUtil.parse(xmlFragment, isLogging);
@@ -44,10 +44,10 @@ public class SimpleContentFilterTestCase {
     }
 
     @Test
-    public void testSimpleContentWithEnumeration() throws Exception {        
-        final boolean isLogging = false;        
-        final String xmlFragment = 
-        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+    public void testSimpleContentWithEnumeration() throws Exception {
+        final boolean isLogging = false;
+        final String xmlFragment =
+        "<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
         "   <xsd:complexType name=\"ejb-ref-typeType\">" +
         "      <xsd:simpleContent>" +
         "          <xsd:restriction base=\"j2ee:string\">" +

--- a/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/UnionFilterTestCase.java
+++ b/metadata-parser/src/test/java/org/jboss/shrinkwrap/descriptor/metadata/filter/UnionFilterTestCase.java
@@ -1,6 +1,6 @@
 package org.jboss.shrinkwrap.descriptor.metadata.filter;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.metadata.DomTestUtil;
 import org.jboss.shrinkwrap.descriptor.metadata.Metadata;
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 /**
  * Test class testing the {@link UnionFilter} class.
- * 
+ *
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public class UnionFilterTestCase {
@@ -17,7 +17,7 @@ public class UnionFilterTestCase {
     public void testUnionFilterWithSimpleTypeAsParent() throws Exception {
         final boolean isLogging = false;
         final String xmlFragment =
-		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" + 
+		"<xsd:schema xmlns=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" >" +
 		"   <xsd:simpleType name=\"protocol-bindingType\">" +
 		"      <xsd:union memberTypes=\"xsd:anyURI javaee:protocol-URIAliasType\"/>" +
 		"   </xsd:simpleType>" +

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
                         <showWarnings>true</showWarnings>
                         <optimize>true</optimize>
                         <compilerVersion>1.6</compilerVersion>
-                        <fork>true</fork>
+                        <fork>false</fork>
                         <compilerArguments>
                             <source>1.5</source>
                             <target>1.5</target>

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/AbsoluteGetQueryTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/AbsoluteGetQueryTestCase.java
@@ -28,7 +28,7 @@ import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.createTr
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.test.util.NodeAssert;
 import org.junit.Test;

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/AbsoluteGetSingleQueryTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/AbsoluteGetSingleQueryTestCase.java
@@ -26,12 +26,12 @@ import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.CHILD_3_
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.CHILD_3_TEXT;
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.ROOT_NODE;
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.createTree;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 
 /**
- * 
+ *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * @version $Revision: $

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/GetOrCreateQueryTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/GetOrCreateQueryTestCase.java
@@ -27,12 +27,12 @@ import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.ROOT_NOD
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.junit.Test;
 
 /**
- * 
+ *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * @version $Revision: $

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/PatternTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/PatternTestCase.java
@@ -18,7 +18,7 @@ package org.jboss.shrinkwrap.descriptor.spi.node;
 
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
 import org.jboss.shrinkwrap.descriptor.spi.node.Pattern;
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 /**
  * Test cases to ensure that {@link Pattern} is working as contracted
- * 
+ *
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
  */
 public class PatternTestCase
@@ -107,7 +107,7 @@ public class PatternTestCase
       final String oneAttributeValue = pattern.getAttribute(ONE);
       Assert.assertEquals("Attribute value not as expected", TWO, oneAttributeValue);
    }
-   
+
    @Test
    public void attributeFromObjectRoundtrip()
    {

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/RelativeGetQueryTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/RelativeGetQueryTestCase.java
@@ -29,7 +29,7 @@ import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.createTr
 
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.test.util.NodeAssert;
 import org.junit.Test;

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/RelativeGetSingleQueryTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/RelativeGetSingleQueryTestCase.java
@@ -25,13 +25,13 @@ import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.CHILD_3_
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.CHILD_3_TEXT;
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.ROOT_NODE;
 import static org.jboss.shrinkwrap.descriptor.test.util.TestTreeBuilder.createTree;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.test.util.NodeAssert;
 import org.junit.Test;
 
 /**
- * 
+ *
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  * @author <a href="mailto:lincolnbaxter@gmail.com">Lincoln Baxter, III</a>
  * @version $Revision: $

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/XMLImporterTestCase.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/spi/node/XMLImporterTestCase.java
@@ -18,7 +18,7 @@ package org.jboss.shrinkwrap.descriptor.spi.node;
 
 import java.io.ByteArrayInputStream;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.spi.node.dom.XmlDomNodeImporter;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class XMLImporterTestCase
    		"           </configuration>\n" +
    		"       </container>\n" +
    		"</arquillian>";
-   
+
     @Test
     public void shouldBeAbleToImportNamespace() throws Exception {
         Node root = load();

--- a/spi/src/test/java/org/jboss/shrinkwrap/descriptor/test/util/NodeAssert.java
+++ b/spi/src/test/java/org/jboss/shrinkwrap/descriptor/test/util/NodeAssert.java
@@ -18,7 +18,7 @@ package org.jboss.shrinkwrap.descriptor.test.util;
 
 import java.util.Arrays;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
 
@@ -26,7 +26,7 @@ import org.jboss.shrinkwrap.descriptor.spi.node.Node;
  * {@link Node} related assertions.
  *
  * @author <a href="mailto:bartosz.majsak@gmail.com">Bartosz Majsak</a>
- * 
+ *
  */
 public final class NodeAssert {
 
@@ -51,7 +51,7 @@ public final class NodeAssert {
     /**
      * Verifies if node has expected name.
      *
-     * @param nodes
+     * @param node
      * @param expectedName
      *
      * @throws Exception
@@ -69,7 +69,7 @@ public final class NodeAssert {
      * @param name
      *            Name of the node attribute
      * @param expectedValue
-     * 
+     *
      * @throws Exception
      *             Assertion error when one of node does not match
      */

--- a/test-util/src/main/java/org/jboss/shrinkwrap/descriptor/test/util/XmlAssert.java
+++ b/test-util/src/main/java/org/jboss/shrinkwrap/descriptor/test/util/XmlAssert.java
@@ -28,7 +28,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
@@ -79,7 +79,7 @@ public final class XmlAssert {
      *
      * @param xml
      *            to be verified
-     * @param expectedNamespace
+     * @param expectedURI
      *            expected value of xmlns attribute
      *
      * @throws Exception

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/application5/ApplicationDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/application5/ApplicationDescriptorTestCase.java
@@ -20,7 +20,7 @@ import static org.jboss.shrinkwrap.descriptor.test.util.XmlAssert.assertPresence
 
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.application5.ApplicationDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector10/ConnectorDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector10/ConnectorDescriptorTestCase.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.BufferedReader;
 import java.io.FileReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.connector10.ConnectorDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector15/ConnectorDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector15/ConnectorDescriptorTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.shrinkwrap.descriptor.test.connector15;
 import java.io.BufferedReader;
 import java.io.FileReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.connector15.ConnectorDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector16/ConnectorDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector16/ConnectorDescriptorTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.shrinkwrap.descriptor.test.connector16;
 import java.io.BufferedReader;
 import java.io.FileReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.connector16.ConnectorDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector17/ConnectorDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/connector17/ConnectorDescriptorTestCase.java
@@ -19,7 +19,7 @@ package org.jboss.shrinkwrap.descriptor.test.connector17;
 import java.io.BufferedReader;
 import java.io.FileReader;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.connector17.ConnectorDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/facesconfig20/FacesConfigDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/facesconfig20/FacesConfigDescriptorTestCase.java
@@ -7,7 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileReader;
 import java.io.InputStream;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.facesconfig20.FacesConfigVersionType;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/facesconfig22/FacesConfigDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/facesconfig22/FacesConfigDescriptorTestCase.java
@@ -7,7 +7,7 @@ import java.io.ByteArrayInputStream;
 import java.io.FileReader;
 import java.io.InputStream;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.facesconfig22.FacesConfigVersionType;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portedfrompoc/BeansDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portedfrompoc/BeansDescriptorTestCase.java
@@ -26,7 +26,7 @@ import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Stereotype;
 import javax.interceptor.Interceptor;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.beans10.BeansDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portedfrompoc/PersistenceDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/portedfrompoc/PersistenceDescriptorTestCase.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.List;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/webapp30/WebAppDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/webapp30/WebAppDescriptorTestCase.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.javaee6.IconType;
@@ -39,7 +39,7 @@ public class WebAppDescriptorTestCase {
         "        <filter-name>UrlRewriteFilter</filter-name>\n" +
         "    </filter-mapping>\n" +
         "</web-app>";
- 
+
     @Test
     public void shouldCreateDefaultName() throws Exception {
         Assert.assertEquals("web.xml", create().getDescriptorName());

--- a/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/webapp31/WebAppDescriptorTestCase.java
+++ b/test/src/test/java/org/jboss/shrinkwrap/descriptor/test/webapp31/WebAppDescriptorTestCase.java
@@ -9,7 +9,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.logging.Logger;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.javaee7.IconType;
@@ -39,7 +39,7 @@ public class WebAppDescriptorTestCase {
         "        <filter-name>UrlRewriteFilter</filter-name>\n" +
         "    </filter-mapping>\n" +
         "</web-app>";
- 
+
     @Test
     public void shouldCreateDefaultName() throws Exception {
         Assert.assertEquals("web.xml", create().getDescriptorName());


### PR DESCRIPTION
The build would not consistently build on my machine with the deprecated junit.framework.Assert usage and fork=true on the maven-compiler-plugin.

This change removes those deprecations, sets fork=false, and seems to work in all cases on my localhost.

I don't honestly know why.