### PR TITLE
Update parent-pom, run with Java 8 not 5, ci build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# GitHub Dependabot configuration file
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for maven
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,30 @@
+name: Java Build, Test
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+    - name: Set up JDK 21
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B verify --file pom.xml
+    - name: Upload Test Reports
+      if:  always()
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      with:
+        name: Test-reports
+        path: |
+          **/test-reports/*/TEST-*.xml

--- a/ant/pom.xml
+++ b/ant/pom.xml
@@ -36,17 +36,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/build-resources/src/main/resources/code-style/checkstyle.xml
+++ b/build-resources/src/main/resources/code-style/checkstyle.xml
@@ -16,8 +16,6 @@
 
     <module name="TreeWalker">
 
-        <property name="cacheFile" value="${checkstyle.cache.file}"/>
-
         <!-- Checks for imports                              -->
         <module name="AvoidStarImport"/>
         <module name="RedundantImport"/>
@@ -37,9 +35,7 @@
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
-        <module name="RedundantThrows">
-            <property name="allowUnchecked" value="true"/>
-        </module>
+        <module name="RedundantModifier"/>
 
         <!-- Miscellaneous other checks.                   -->
         <module name="UpperEll"/>

--- a/gen/pom.xml
+++ b/gen/pom.xml
@@ -94,14 +94,6 @@
             </plugin>
 
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                </configuration>
-            </plugin>
-
-            <plugin>
 				<groupId>org.jboss.shrinkwrap.descriptors</groupId>
 				<artifactId>shrinkwrap-descriptors-metadata-parser</artifactId>
 				<version>${project.version}</version>

--- a/impl-base/pom.xml
+++ b/impl-base/pom.xml
@@ -49,16 +49,6 @@
     <build>
         <plugins>
 
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                </configuration>
-            </plugin>
-
             <!-- Export test JAR for use in other modules -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/impl-javaee-prototype/pom.xml
+++ b/impl-javaee-prototype/pom.xml
@@ -45,19 +45,4 @@
 
   </dependencies>
 
-	<build>
-		<plugins>
-			<!-- Surefire -->
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<!-- Run in Java5; be build with a JDK6 compiler so ensure we don't 
-						use any JDK6 libs -->
-					<jvm>${env.JAVA5_HOME}/bin/java</jvm>
-          <!-- Speeeeeeed -->
-          <forkMode>once</forkMode>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/impl-javaee/pom.xml
+++ b/impl-javaee/pom.xml
@@ -58,19 +58,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/impl-jboss/pom.xml
+++ b/impl-jboss/pom.xml
@@ -58,19 +58,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/impl-misc/pom.xml
+++ b/impl-misc/pom.xml
@@ -63,19 +63,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/meta-data-pom.xml
+++ b/meta-data-pom.xml
@@ -104,39 +104,6 @@
         </configuration>
       </plugin>
 
-      <!-- Enforce Maven Environment -->
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-maven-environment</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <rules>
-            <requireMavenVersion>
-              <version>[2.2.0,)</version>
-              <!-- Must be more that 2.2 to support Assembly "includeModuleDirectory": 
-                http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html -->
-            </requireMavenVersion>
-            <requireJavaVersion>
-              <version>[1.5.0,)</version> <!-- Must be at least JDK5 -->
-            </requireJavaVersion>
-            <requireProperty>
-              <property>env.JAVA_HOME</property>
-              <message>"JAVA_HOME needs to be set to compile"</message>
-            </requireProperty>
-<!--            <requireProperty>
-              <property>env.JAVA5_HOME</property>
-              <message>"JAVA5_HOME needs to be set to run some tests in the JRE5 runtime"</message>
-            </requireProperty>-->
-          </rules>
-        </configuration>
-      </plugin>
-      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/metadata-parser-test/pom.xml
+++ b/metadata-parser-test/pom.xml
@@ -140,17 +140,6 @@
                 </executions>
             </plugin>
 
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/metadata-parser-test/pom.xml~
+++ b/metadata-parser-test/pom.xml~
@@ -42,17 +42,6 @@
         </executions>
       </plugin>
       
-      <!-- Surefire -->
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't 
-            use any JDK6 libs -->
-          <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-          <!-- Speeeeeeed -->
-          <forkMode>once</forkMode>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   

--- a/metadata-parser/pom.xml
+++ b/metadata-parser/pom.xml
@@ -37,17 +37,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                    <!-- Speeeeeeed -->
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 
@@ -127,12 +116,12 @@
             <version>1.1</version>
         </dependency>
 
-        <dependency>
-            <groupId>dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>1.6.1</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.dom4j</groupId>
+			<artifactId>dom4j</artifactId>
+			<version>2.1.4</version>
+			<scope>test</scope>
+		</dependency>
 
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
@@ -141,7 +130,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Testing -->
+		<!-- Testing -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/filter/Filter.java
+++ b/metadata-parser/src/main/java/org/jboss/shrinkwrap/descriptor/metadata/filter/Filter.java
@@ -26,5 +26,5 @@ import org.w3c.dom.traversal.TreeWalker;
  * @author <a href="mailto:ralf.battenfeld@bluewin.ch">Ralf Battenfeld</a>
  */
 public interface Filter {
-    boolean filter(final Metadata metadata, final TreeWalker walker);
+    boolean filter(Metadata metadata, TreeWalker walker);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>16</version>
+        <version>39</version>
     </parent>
 
     <!-- Model Information -->
@@ -79,6 +79,7 @@
     <build>
         <plugins>
 
+
             <!-- Release -->
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
@@ -102,38 +103,6 @@
                         <include>**/*TestSuite.java</include>
                     </includes>
                     <forkMode>always</forkMode>
-                </configuration>
-            </plugin>
-
-            <!-- Enforce Maven Environment -->
-            <plugin>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-maven-environment</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <rules>
-                        <requireMavenVersion>
-                            <version>[2.2.0,)</version>
-                            <!-- Must be more that 2.2 to support Assembly "includeModuleDirectory":
-                                http://maven.apache.org/plugins/maven-assembly-plugin/assembly.html -->
-                        </requireMavenVersion>
-                        <requireJavaVersion>
-                            <version>[1.5.0,)</version>
-                            <!-- Must be at least JDK5 -->
-                        </requireJavaVersion>
-                        <requireProperty>
-                            <property>env.JAVA_HOME</property>
-                            <message>"JAVA_HOME needs to be set to compile"</message>
-                        </requireProperty>
-                        <!-- <requireProperty> <property>env.JAVA5_HOME</property> <message>"JAVA5_HOME
-                            needs to be set to run some tests in the JRE5 runtime"</message> </requireProperty> -->
-                    </rules>
                 </configuration>
             </plugin>
 
@@ -184,15 +153,15 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <inherited>true</inherited>
                     <configuration>
-                        <source>1.6</source>
-                        <target>1.6</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                         <showWarnings>true</showWarnings>
                         <optimize>true</optimize>
-                        <compilerVersion>1.6</compilerVersion>
+                        <compilerVersion>1.8</compilerVersion>
                         <fork>true</fork>
                         <compilerArguments>
-                            <source>1.5</source>
-                            <target>1.5</target>
+                            <source>1.8</source>
+                            <target>1.8</target>
                         </compilerArguments>
                     </configuration>
                 </plugin>
@@ -200,7 +169,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.9.1</version>
+<!--                    <version>2.9.1</version>-->
                     <configuration>
                         <configLocation>code-style/checkstyle.xml</configLocation>
                         <logViolationsToConsole>true</logViolationsToConsole>

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/Pattern.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/Pattern.java
@@ -51,7 +51,7 @@ final class Pattern {
      * @throws IllegalArgumentException
      *             If the name is not specified
      */
-    public Pattern(final String name) throws IllegalArgumentException {
+    Pattern(final String name) throws IllegalArgumentException {
         // Precondition check
         if (name == null || name.trim().length() == 0) {
             throw new IllegalArgumentException("name must be specified");

--- a/test-util/pom.xml
+++ b/test-util/pom.xml
@@ -53,16 +53,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
-
-			<!-- Surefire -->
-			<plugin>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-						use any JDK6 libs -->
-					<jvm>${env.JAVA5_HOME}/bin/java</jvm>
-				</configuration>
-			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -81,22 +81,11 @@
         </dependency>
 
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-
-            <!-- Surefire -->
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- Run in Java5; be build with a JDK6 compiler so ensure we don't
-                        use any JDK6 libs -->
-                    <jvm>${env.JAVA5_HOME}/bin/java</jvm>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
- jboss-parent from 165 to 39
- rm maven-enforcer-plugin with
 - requireMavenVersion >2.2.0
 - requireJavaVersion 1.5.0
- rm java5 surefire test
- fix checkstyle in code and xml
- add dependabot
- add ci build

the CI-run-result:
https://github.com/stbischof/descriptors/actions/runs/9253381979/job/25452935504

@petrberan please review and merge