### PR TITLE
Fix NodeDescriptorImporterBase.fromString to handle non ascii chars in xml file

### DIFF
--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/NodeDescriptorImporterBase.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/NodeDescriptorImporterBase.java
@@ -16,7 +16,10 @@
  */
 package org.jboss.shrinkwrap.descriptor.spi.node;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.lang.reflect.Constructor;
 
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
@@ -88,6 +91,52 @@ public abstract class NodeDescriptorImporterBase<T extends Descriptor> extends D
 
         // Return
         return descriptor;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.descriptor.api.DescriptorImporter#fromString(String)
+     */
+    @Override
+    public T fromString(final String in) throws IllegalArgumentException,
+        DescriptorImportException {
+        // Precondition check
+        if (in == null  || in.length() == 0) {
+            throw new IllegalArgumentException("Input string must be specified");
+        }
+
+        Reader reader = new StringReader(in);
+        try {
+            final Node rootNode = this.getNodeImporter().importAsNode(reader);
+
+            // Create the end-user view
+            final Constructor<T> constructor;
+            try {
+                constructor = endUserViewImplType.getConstructor(String.class, Node.class);
+            } catch (final NoSuchMethodException e) {
+                throw new DescriptorImportException("Descriptor impl " + endUserViewImplType.getName()
+                    + " does not have a constructor accepting " + String.class.getName() + " and " + Node.class.getName(),
+                    e);
+            }
+            final T descriptor;
+            try {
+                descriptor = constructor.newInstance(descriptorName, rootNode);
+            } catch (final Exception e) {
+                throw new DescriptorImportException("Could not create new instance using " + constructor + " with arg: "
+                    + rootNode);
+            }
+
+            // Return
+            return descriptor;
+        }
+        finally {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                throw new DescriptorImportException("Exception while closing StringReader", e);
+            }
+        }
     }
 
     // -------------------------------------------------------------------------------------||

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/NodeImporter.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/NodeImporter.java
@@ -17,6 +17,7 @@
 package org.jboss.shrinkwrap.descriptor.spi.node;
 
 import java.io.InputStream;
+import java.io.Reader;
 
 /**
  * Imports a {@link InputStream} into a hierarchal {@link Node} structure
@@ -38,4 +39,14 @@ public interface NodeImporter {
      */
     Node importAsNode(InputStream stream, boolean close) throws IllegalArgumentException;
 
+    /**
+     * Imports the specified {@link Reader} into a {@link Node} structure, returning the root {@link Node}.
+     *
+     * @param input
+     *            The reader containing the xml file content
+     * @return
+     * @throws IllegalArgumentException
+     *             If the reader is not specified
+     */
+    Node importAsNode(Reader input) throws IllegalArgumentException;
 }

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporter.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporter.java
@@ -17,6 +17,7 @@
 package org.jboss.shrinkwrap.descriptor.spi.node.dom;
 
 import java.io.InputStream;
+import java.io.Reader;
 
 import org.jboss.shrinkwrap.descriptor.api.DescriptorImporter;
 import org.jboss.shrinkwrap.descriptor.spi.node.Node;
@@ -43,6 +44,15 @@ public enum XmlDomNodeImporter implements NodeImporter {
      */
     public Node importAsNode(InputStream stream, boolean close) throws IllegalArgumentException {
         return delegate.importAsNode(stream, close);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.descriptor.spi.node.NodeImporter#importAsNode(Reader)
+     */
+    public Node importAsNode(Reader input) throws IllegalArgumentException {
+        return delegate.importAsNode(input);
     }
 
 }

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporterImpl.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporterImpl.java
@@ -18,6 +18,8 @@ package org.jboss.shrinkwrap.descriptor.spi.node.dom;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -31,6 +33,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 
 /**
  * {@link NodeImporter} implementation backed by the {@link Document} API.
@@ -85,6 +88,37 @@ public final class XmlDomNodeImporterImpl implements NodeImporter {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.shrinkwrap.descriptor.spi.node.NodeImporter#importAsNode(Reader)
+     */
+    @Override
+    public Node importAsNode(Reader reader) throws IllegalArgumentException {
+        try {
+            // Empty contents? If so, no root Node
+            if (reader == null || reader.ready() == false) {
+                return null;
+            }
+
+            final DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            final DocumentBuilder builder = factory.newDocumentBuilder();
+            InputSource source = new InputSource(reader);
+            final Document doc = builder.parse(source);
+
+            final Element element = doc.getDocumentElement();
+
+            final Node root = new Node(element.getNodeName());
+
+            readRecursive(root, element);
+            return root;
+
+        } catch (final Exception e) {
+            throw new DescriptorImportException("Could not import XML from string", e);
         }
     }
 

--- a/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporterImpl.java
+++ b/spi/src/main/java/org/jboss/shrinkwrap/descriptor/spi/node/dom/XmlDomNodeImporterImpl.java
@@ -19,7 +19,6 @@ package org.jboss.shrinkwrap.descriptor.spi.node.dom;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 


### PR DESCRIPTION
This fixes #119

Arqullian uses this code to parse "arquillian.xml": https://github.com/arquillian/arquillian-core/blob/main/config/impl-base/src/main/java/org/jboss/arquillian/config/impl/extension/ClasspathConfigurationPlaceholderResolver.java
It exports a descriptor to a string, replaces some placeholders and reimports the descriptor from this string.
This fails if "arquillian.xml" contains non-ascii chars (though the xml files defines "UTF-8" encoding).

This pull request adds an override `fromString` to `NodeDescriptorImporterBase`. In this method, I create a `java.io.StringReader`, which is passed to the new method `NodeImporter.importAsNode(Reader)`, implemented in `XmlDomNodeImporterImpl`. Here, a `org.xml.sax.InputSource` is created using this Reader, and the `DocumentBuilder` parses this source.

The `NodeDescriptorImporterBase` base class `DescriptorImporterBase` still contains the previous implementation of `fromString` that calls `fromStream(new ByteArrayInputStream(string.getBytes()))`. I would have preferred to add a `fromReader` to the base class too, but this would have meant adding a method to the interface `org.jboss.shrinkwrap.descriptor.api.DescriptorImporter`.


Things to improve - please give me feedback:

- `NodeDescriptorImporterBase`: the existing `fromStream` and my new method `fromString` contain similar code. The part after the comment "// Create the end-user view" could be extracted to a helper method.
- same applies to `XmlDomNodeImporterImpl.importAsNode(Reader)`.
- I didn't add a test. Actually, I don't have an idea how to implement one - probably I would have to do something similar to the arquillian code and load the arquillian descriptor from a file, convert to a string and re-parse it from this string? But currently, the test suite does not run for me - probably because I use Java 1.8 and it requires older versions? I saw that there is a pull request to switch to Java 1.8 - maybe this one fixes the test suite.

I tested it in my sample project and will attach a ut8 "arquillian.xml" and a "windows-1252" file (both containing umlauts in a comment) to #119. Both files did not show the failure from the initial bugreport.